### PR TITLE
Enhance CPanel with Badge Generation for Cron Jobs

### DIFF
--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -4,6 +4,7 @@ namespace GuiBranco\ProjectsMonitor\Library;
 
 use GuiBranco\ProjectsMonitor\Library\Configuration;
 use GuiBranco\Pancake\Request;
+use GuiBranco\Pancake\ShieldsIo;
 
 class CPanel
 {
@@ -184,13 +185,16 @@ class CPanel
         );
         $response = $this->getRequest("json-api", "cpanel", $parameters);
         $lines = $response->cpanelresult->data;
+        $badge = new ShieldsIo();
         foreach ($lines as $line) {
             if (!isset($line->command) || $line->command == null) {
                 continue;
             }
             $command = str_replace("/home/zerocool/", "", str_replace("/usr/local/bin/", "", $line->command));
             $time = $line->minute . " " . $line->hour . " " . $line->day . " " . $line->month . " " . $line->weekday;
-            $result[] = array($command, $time);
+            $badgeUrl = $badge->generateBadgeUrl("⏰", $time, "black", "for-the-badge", "white");
+            $timeBadge = "<img alt='Cron expression' src='{$badgeUrl}' />";
+            $result[] = array($command, $timeBadge);
         }
 
         sort($result, SORT_ASC);


### PR DESCRIPTION
### **Description**
- Introduced `ShieldsIo` to generate badges for cron job time expressions.
- Modified the `getCrons` method to return an HTML image tag for badges.
- Improved user interface by visually representing cron job timings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CPanel.php</strong><dd><code>Enhance CPanel with Badge Generation for Cron Jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Library/CPanel.php
<li>Added a new dependency <code>ShieldsIo</code> for badge generation.<br> <li> Integrated badge generation for cron job time display.<br> <li> Updated the output format of cron jobs to include badges.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/472/files#diff-b2d958c539486a701b5b2831ad8ebcd458c2cbf481ff1b4e676d5a0be0d48663">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>