### PR TITLE
Fix badge URL generation in CPanel

### DIFF
--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -192,7 +192,7 @@ class CPanel
             }
             $command = str_replace("/home/zerocool/", "", str_replace("/usr/local/bin/", "", $line->command));
             $time = $line->minute . " " . $line->hour . " " . $line->day . " " . $line->month . " " . $line->weekday;
-            $badgeUrl = $badge->generateBadgeUrl("⏰", $time, "black", "for-the-badge", "white");
+            $badgeUrl = $badge->generateBadgeUrl("⏰", $time, "black", "for-the-badge", "white", null);
             $timeBadge = "<img alt='Cron expression' src='{$badgeUrl}' />";
             $result[] = array($command, $timeBadge);
         }


### PR DESCRIPTION
### **Description**
- Fixed the `generateBadgeUrl` method call in `CPanel.php` to include a `null` parameter.
- This change addresses potential issues with badge generation for cron jobs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CPanel.php</strong><dd><code>Fix badge URL generation in CPanel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/Library/CPanel.php
<li>Updated <code>generateBadgeUrl</code> method call to include a new parameter.<br> <li> Ensured compatibility with the latest badge generation requirements.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/473/files#diff-2c1645f63731d9469f363cb95b7d8f035b1c91712aeb5efcdfb5fddcd85888b0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>