### PR TITLE
Improve output format in CPanel.php

### DIFF
--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -196,11 +196,11 @@ class CPanel
             $time = $line->minute . " " . $line->hour . " " . $line->day . " " . $line->month . " " . $line->weekday;
             $badgeUrl = $badge->generateBadgeUrl("⏰", $time, "black", "for-the-badge", "white", null);
             $timeBadge = "<img alt='Cron expression' src='{$badgeUrl}' />";
-            $result[] = array($command, $timeBadge);
+            $result[] = array($timeBadge, $command);
         }
 
         sort($result, SORT_ASC);
-        array_unshift($result, array("Command", "Expression"));
+        array_unshift($result, array("Expression", "Command"));
         return $result;
     }
 }


### PR DESCRIPTION
### **Description**
- Enhanced the output format of the `getCrons` function in `CPanel.php`.
- Adjusted the order of the command and time badge for clarity.
- Updated the header labels to reflect the new order.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CPanel.php</strong><dd><code>Improve output format in CPanel.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Library/CPanel.php
<li>Changed the order of elements in the result array for better <br>readability.<br> <li> Updated the header of the result array to match the new order.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/479/files#diff-b2d958c539486a701b5b2831ad8ebcd458c2cbf481ff1b4e676d5a0be0d48663">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>