### PR TITLE
Skip processing of files in the ".trash" directory in CPanel.php

### DIFF
--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -132,6 +132,9 @@ class CPanel
         $items = $this->searchFiles("error_log", "/");
 
         foreach ($items as $item) {
+            if (strpos($item, ".trash") !== false) {
+                continue;
+            }
             $stats = $this->loadStats($item->file);
             $result[] = array(str_replace("/home/{$this->username}/", "", $stats["dirname"]), $stats["humansize"], $stats["mtime"]);
         }


### PR DESCRIPTION
### **Description**
- Fixed an issue where files in the ".trash" directory were being processed in the `getErrorLogFiles` method.
- Improved the overall functionality by ensuring only relevant files are considered.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CPanel.php</strong><dd><code>Skip processing of files in the ".trash" directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/Library/CPanel.php
<li>Added a check to skip files in the ".trash" directory.<br> <li> Enhanced the <code>getErrorLogFiles</code> method to avoid processing unwanted <br>files.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/484/files#diff-2c1645f63731d9469f363cb95b7d8f035b1c91712aeb5efcdfb5fddcd85888b0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>