### PR TITLE
Enhance error log file filtering in CPanel.php

### DIFF
--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -132,7 +132,7 @@ class CPanel
         $items = $this->searchFiles("error_log", "/");
 
         foreach ($items as $item) {
-            if (strpos($item, ".trash") !== false) {
+            if (strpos($item->file, ".trash") !== false) {
                 continue;
             }
             $stats = $this->loadStats($item->file);


### PR DESCRIPTION
### **Description**
- Enhanced the `getErrorLogFiles` method to check for ".trash" in the `file` property of items.
- This change improves the accuracy of error log file filtering.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CPanel.php</strong><dd><code>Enhance error log file filtering in CPanel.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Library/CPanel.php
<li>Updated the method to check for ".trash" in the file property.<br> <li> Improved the error log file filtering logic.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/486/files#diff-b2d958c539486a701b5b2831ad8ebcd458c2cbf481ff1b4e676d5a0be0d48663">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>