### PR TITLE
Enhance error log handling in CPanel.php

### DIFF
--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -135,7 +135,7 @@ class CPanel
             if (strpos($item->file, ".trash") !== false) {
                 continue;
             }
-            
+
             $stats = $this->loadStats($item->file);
             $result[] = array(str_replace("/home/{$this->username}/", "", $stats["dirname"]), $stats["humansize"], $stats["mtime"]);
         }
@@ -159,7 +159,7 @@ class CPanel
             if (strpos($item->file, ".trash") !== false) {
                 continue;
             }
-            
+
             $content = $this->loadContent($item->file);
 
             if ($content === null) {

--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -135,6 +135,7 @@ class CPanel
             if (strpos($item->file, ".trash") !== false) {
                 continue;
             }
+            
             $stats = $this->loadStats($item->file);
             $result[] = array(str_replace("/home/{$this->username}/", "", $stats["dirname"]), $stats["humansize"], $stats["mtime"]);
         }
@@ -155,6 +156,10 @@ class CPanel
         $items = $this->searchFiles("error_log", "/");
 
         foreach ($items as $item) {
+            if (strpos($item->file, ".trash") !== false) {
+                continue;
+            }
+            
             $content = $this->loadContent($item->file);
 
             if ($content === null) {


### PR DESCRIPTION
### **Description**
- Introduced logic to ignore files located in the ".trash" directory when retrieving error log files and messages.
- Improved the robustness of the `getErrorLogFiles` and `getErrorLogMessages` methods.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CPanel.php</strong><dd><code>Enhance error log file handling in CPanel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Library/CPanel.php
<li>Added checks to skip files in the ".trash" directory.<br> <li> Enhanced the <code>getErrorLogFiles</code> and <code>getErrorLogMessages</code> methods.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/487/files#diff-b2d958c539486a701b5b2831ad8ebcd458c2cbf481ff1b4e676d5a0be0d48663">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>