### PR TITLE
Refactor API usage access in Postman.php

### DIFF
--- a/Src/Library/Postman.php
+++ b/Src/Library/Postman.php
@@ -53,7 +53,7 @@ class Postman
     {
         $shields = new ShieldsIo();
         $me = $this->doRequest("me");
-        $apiUsage = isset($me["operations"]) && isset($me["operations"][""]) ? $me["operations"]["api_usage"] : null;
+        $apiUsage = isset($me->operations) && isset($me->operations->api_usage) ? $me->operations->api_usage : null;
 
         if ($apiUsage === null) {
             return "<a href='https://web.postman.co/billing/add-ons/overview'>Error</a>";


### PR DESCRIPTION
### **Description**
- Refactored the `getUsage` method to access `api_usage` using object notation instead of array notation.
- This change enhances code clarity and aligns with modern PHP practices.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Postman.php</strong><dd><code>Refactor API usage access in Postman.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Library/Postman.php
<li>Changed the way API usage is accessed from an array to an object.<br> <li> Improved code readability and maintainability.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/495/files#diff-4857c2dab714bcc3002a000269098a182ba9faf47a4b52dcad58d2fa5e99e0b0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>