### PR TITLE
Create and Define Errors Table for Logging

### DIFF
--- a/Sql/0007.create_errors_table.sql
+++ b/Sql/0007.create_errors_table.sql
@@ -3,12 +3,18 @@ DROP TABLE IF EXISTS `errors`;
 CREATE TABLE
     `errors` (
         `id` int NOT NULL AUTO_INCREMENT,
-        `date` DATETIME NOT NULL,
         `error_log_path` varchar(255) NOT NULL,
+        `date` datetime NOT NULL,
+        `error` text NOT NULL,
+        `error_multiline` text NOT NULL,
         `file` varchar(255) NOT NULL,
-        `line` int (11) NOT NULL,        
-        `message` text NOT NULL,
-        `details` text NULL,
+        `line` int (11) NOT NULL,
+        `stack_trace` text NULL,
+        `stack_trace_details` text NULL,
+        `repository` varchar(255) NULL,
+        `issue_number` int NULL,
+        `issue_created_at` timestamp NULL,
         `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+        `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()
         PRIMARY KEY (`id`)
     ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/Sql/0007.create_errors_table.sql
+++ b/Sql/0007.create_errors_table.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS `errors`;
+
+CREATE TABLE
+    `errors` (
+        `id` int NOT NULL AUTO_INCREMENT,
+        `date` DATETIME NOT NULL,
+        `error_log_path` varchar(255) NOT NULL,
+        `file` varchar(255) NOT NULL,
+        `line` int (11) NOT NULL,        
+        `message` text NOT NULL,
+        `details` text NULL,
+        `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+        PRIMARY KEY (`id`)
+    ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/Sql/0007.create_errors_table.sql
+++ b/Sql/0007.create_errors_table.sql
@@ -15,6 +15,6 @@ CREATE TABLE
         `issue_number` int NULL,
         `issue_created_at` timestamp NULL,
         `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
-        `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp()
+        `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
         PRIMARY KEY (`id`)
     ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
### **Description**
- Introduced a new `errors` table to facilitate error logging.
- The table includes fields for error details, timestamps, and repository context.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0007.create_errors_table.sql</strong><dd><code>Create and Define Errors Table for Logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sql/0007.create_errors_table.sql
<li>Dropped the existing <code>errors</code> table if it exists.<br> <li> Created a new <code>errors</code> table with various fields for error logging.<br> <li> Included fields for error details, timestamps, and repository <br>information.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/505/files#diff-09818d53e86146841ea3f88acbe2f0d8b5d065eb6ff85f9d6b9e823328b59b14">+20/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>