### PR TITLE
Fix percentage formatting in Postman badge URL

### DIFF
--- a/Src/Library/Postman.php
+++ b/Src/Library/Postman.php
@@ -87,7 +87,7 @@ class Postman
             $color = "yellow";
         }
 
-        $badge = $shields->generateBadgeUrl(number_format($percentage, 2, '.', '') . "%25", "{$usage}/{$limit} Postman API Usage", $color, "for-the-badge", "black", null);
+        $badge = $shields->generateBadgeUrl(number_format($percentage, 2, '.', '') . "%", "{$usage}/{$limit} Postman API Usage", $color, "for-the-badge", "black", null);
         return "<a href='https://web.postman.co/billing/add-ons/overview'><img src='{$badge}' alt='Postman API usage' /></a>";
     }
 


### PR DESCRIPTION
### **User description**
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes/features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->

- [ ] Yes
- [ ] No

----


___

### **Description**
- Corrected the percentage formatting in the badge URL generation for Postman API usage.
- This change improves the clarity of the displayed usage percentage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Postman.php</strong><dd><code>Fix percentage formatting in Postman badge URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Library/Postman.php
<li>Updated badge URL generation to correct percentage formatting.<br> <li> Changed from "%25" to "%" in the badge URL.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/506/files#diff-4857c2dab714bcc3002a000269098a182ba9faf47a4b52dcad58d2fa5e99e0b0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>