### PR TITLE
Enhance percentage formatting in Postman badge generation

### DIFF
--- a/Src/Library/Postman.php
+++ b/Src/Library/Postman.php
@@ -64,8 +64,13 @@ class Postman
             $color = "yellow";
         }
 
+        $percentageStr = number_format($percentage, 2, '.', '')."%";
+        if ($percentage < 10) {
+            $percentageStr = "0" . $percentageStr;
+        }
+        
         $shields = new ShieldsIo();
-        $badge = $shields->generateBadgeUrl(number_format($percentage, 2, '.', '')."%", "{$usage}/{$limit} {$label}", $color, "for-the-badge", "black", null);
+        $badge = $shields->generateBadgeUrl($percentageStr, "{$usage}/{$limit} {$label}", $color, "for-the-badge", "black", null);
         return "<a href='https://web.postman.co/billing/add-ons/overview'><img src='{$badge}' alt='{$label}' /></a>";
     }
 

--- a/Src/Library/Postman.php
+++ b/Src/Library/Postman.php
@@ -68,7 +68,7 @@ class Postman
         if ($percentage < 10) {
             $percentageStr = "0" . $percentageStr;
         }
-        
+
         $shields = new ShieldsIo();
         $badge = $shields->generateBadgeUrl($percentageStr, "{$usage}/{$limit} {$label}", $color, "for-the-badge", "black", null);
         return "<a href='https://web.postman.co/billing/add-ons/overview'><img src='{$badge}' alt='{$label}' /></a>";


### PR DESCRIPTION
### **Description**
- Improved the display of percentage values in badges by formatting them to two decimal places.
- Added a condition to prefix percentages less than 10% with a leading zero for better readability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Postman.php</strong><dd><code>Enhance badge percentage formatting in Postman.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Library/Postman.php
<li>Added formatting for percentage display in badge.<br> <li> Ensured percentages below 10% are prefixed with a zero.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/519/files#diff-4857c2dab714bcc3002a000269098a182ba9faf47a4b52dcad58d2fa5e99e0b0">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved formatting of percentage display in badge URLs for better readability, ensuring consistent two-digit representation.
  
- **Bug Fixes**
	- Enhanced visual representation for percentages below 10%, now displayed as "0X.XX%".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->