### PR TITLE
Enhance SSH Peer Connection Status Logic

### DIFF
--- a/Src/.htaccess
+++ b/Src/.htaccess
@@ -1,9 +1,5 @@
 RewriteEngine On
 
-<Files "install.php">
-    Require all denied
-</Files>
-
 <Files "deploy.zip">
     Require all denied
 </Files>

--- a/Src/Library/SSH.php
+++ b/Src/Library/SSH.php
@@ -142,14 +142,26 @@ class SSH
                 continue;
             }
 
-            $connected = array_key_exists('latest handshake', $peer) ? true : false;
-            $label = $connected ? "🟢" : "🔴";
-            $content = $connected ? "Connected" : "Disconnected";
-            $color = $connected ? "brightgreen" : "red";
+            $handshake = array_key_exists('latest handshake', $peer) ? true : false;
+            $time = $handshake ? strtotime($peer["latest handshake"]) : 0;
+            $diff = time() - $time;
+            
+            $label = "🔴";
+            $content = "Disconnected";
+            $color = "red";
 
+            if ($handshake === true && $diff > 600) {
+                $label = "🟠";
+                $content = "Inactive";
+                $color = "orange";
+            } else if ($handshake === true) {
+                $label =  "🟢";
+                $content = "Active";
+                $color = "brightgreen";
+            }
+            
             $status = $shields->generateBadgeUrl($label, $content, $color, "for-the-badge", "white", null);
             $statusImg = "<img src='$status' alt='Status' />";
-
 
             $peers[] = array(
                 $this->mapPeerToHostname($peer['allowed ips']),

--- a/Src/Library/SSH.php
+++ b/Src/Library/SSH.php
@@ -145,7 +145,7 @@ class SSH
             $handshake = array_key_exists('latest handshake', $peer) ? true : false;
             $time = $handshake ? strtotime($peer["latest handshake"]) : 0;
             $diff = time() - $time;
-            
+
             $label = "🔴";
             $content = "Disconnected";
             $color = "red";
@@ -154,12 +154,12 @@ class SSH
                 $label = "🟠";
                 $content = "Inactive";
                 $color = "orange";
-            } else if ($handshake === true) {
+            } elseif ($handshake === true) {
                 $label =  "🟢";
                 $content = "Active";
                 $color = "brightgreen";
             }
-            
+
             $status = $shields->generateBadgeUrl($label, $content, $color, "for-the-badge", "white", null);
             $statusImg = "<img src='$status' alt='Status' />";
 


### PR DESCRIPTION
### **Description**
- Enhanced the logic for determining the connection status of peers.
- Introduced new states: "Active", "Inactive", and "Disconnected" based on the latest handshake time.
- Updated the visual representation of connection status with appropriate labels and colors.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SSH.php</strong><dd><code>Enhance Peer Connection Status Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/Library/SSH.php
<li>Improved connection status handling for peers.<br> <li> Added logic to differentiate between "Active", "Inactive", and <br>"Disconnected" states.<br> <li> Updated badge generation based on connection status.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/554/files#diff-3baf7e9bc54e1c8b521f1e6799f5d641373bbd2d0bf7db800331abd1bb051c7e">+18/-6</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>