### PR TITLE
Correct spelling of AppVeyor in index.php

### DIFF
--- a/Src/index.php
+++ b/Src/index.php
@@ -120,7 +120,7 @@ $configuration = new Configuration();
     <div id="cronjobs"></div>
     <div class="topping">Senders</div>
     <div id="senders"></div>
-    <div class="topping">App Veyor</div>
+    <div class="topping">AppVeyor</div>
     <div id="appveyor"></div>
   </div>
   <div style="clear:both;"></div>


### PR DESCRIPTION
### **Description**
- This PR enhances the `index.php` file by correcting the spelling of 'App Veyor' to 'AppVeyor'.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.php</strong><dd><code>Fix spelling of AppVeyor in index.php</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Src/index.php
- Corrected the spelling of 'App Veyor' to 'AppVeyor'.



</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/563/files#diff-c36e974b0230f93b7db2439aded00cfaa35acbf92cf0e85684123eb169812425">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>