### PR TITLE
Remove FTP Accounts and Database gauges

### DIFF
--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -353,7 +353,7 @@ class CPanel
 
         $result = [];
         foreach ($response->data as $item) {
-            if (in_array($item->id, ['lvecpu', 'lvememphy', 'lvenproc', 'lveep', 'ftp_accounts', 'mysql_databases'])) {
+            if (in_array($item->id, ['lvecpu', 'lvememphy', 'lvenproc', 'lveep'])) {
 
                 if ($item->formatter === "format_bytes") {
                     $item->usage = number_format($item->usage / 1024 / 1024, 2, '.', '');

--- a/Src/index.php
+++ b/Src/index.php
@@ -78,8 +78,6 @@ $configuration = new Configuration();
          <div id="gauge_chart_memory" class="gauge"></div>
          <div id="gauge_chart_entry_process" class="gauge"></div>
          <div id="gauge_chart_process" class="gauge"></div>
-         <div id="gauge_chart_databases" class="gauge"></div>
-         <div id="gauge_chart_ftp_accounts" class="gauge"></div>
          <div id="gauge_chart_webhooks" class="gauge"></div>
          <div id="gauge_chart_issues" class="gauge"></div>
          <div id="gauge_chart_pull_requests" class="gauge"></div>

--- a/Src/static/scripts.js
+++ b/Src/static/scripts.js
@@ -359,7 +359,7 @@ function preset() {
   showPreset = false;
   showCPanel(
     JSON.parse(
-      '{"error_log_files":[],"error_log_messages":[],"total_error_messages":0,"cronjobs":[],"usage":[{"id":"ftp_accounts","description":"FTP Accounts","usage":0,"maximum":100},{"id":"mysql_databases","description":"Databases","usage":0,"maximum":100},{"id":"lvecpu","description":"CPU Usage","usage":0,"maximum":100},{"id":"lveep","description":"Entry Processes","usage":0,"maximum":20},{"id":"lvememphy","description":"Physical Memory Usage","usage":0,"maximum":512},{"id":"lvenproc","description":"Number of Processes","usage":0,"maximum":100}]}'
+      '{"error_log_files":[],"error_log_messages":[],"total_error_messages":0,"cronjobs":[],"usage":[{"id":"lvecpu","description":"CPU Usage","usage":0,"maximum":100},{"id":"lveep","description":"Entry Processes","usage":0,"maximum":20},{"id":"lvememphy","description":"Physical Memory Usage","usage":0,"maximum":512},{"id":"lvenproc","description":"Number of Processes","usage":0,"maximum":100}]}'
     )
   );
   showGitHub(
@@ -653,9 +653,7 @@ function showCPanel(response) {
     lvecpu: "gauge_chart_cpu",
     lvememphy: "gauge_chart_memory",
     lveep: "gauge_chart_entry_process",
-    lvenproc: "gauge_chart_process",
-    ftp_accounts: "gauge_chart_ftp_accounts",
-    mysql_databases: "gauge_chart_databases",
+    lvenproc: "gauge_chart_process",   
   };
 
   const labels = {
@@ -663,8 +661,6 @@ function showCPanel(response) {
     lvememphy: "Memory",
     lveep: "Entry Processes",
     lvenproc: "Processes",
-    ftp_accounts: "FTPs",
-    mysql_databases: "Databases",
   };
 
   const usageData = response["usage"].map((item) => ({


### PR DESCRIPTION
## 📑 Description
Remove FTP Accounts and Database gauges

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

## Summary by Sourcery

Enhancements:
- Remove FTP accounts and databases from the usage data displayed in the CPanel section.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the FTP Accounts and Database usage gauges from the CPanel.php, index.php, and scripts.js files.

### Why are these changes being made?

These changes are being made to streamline the user interface by removing outdated or unnecessary gauges related to FTP Accounts and Databases, which simplifies the data handling and reduces clutter on the dashboard. The removal helps improve focus on more critical resource usage metrics like CPU, Memory, and Entry Processes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated metrics display to focus on CPU usage, entry processes, and physical memory.
  
- **Bug Fixes**
	- Removed outdated gauge charts for FTP accounts and MySQL databases from the user interface.

- **Refactor**
	- Simplified data processing in the application by removing unnecessary fields related to FTP and MySQL from the JSON structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->