### PR TITLE
Update GitHub.php

### DIFF
--- a/Src/Library/GitHub.php
+++ b/Src/Library/GitHub.php
@@ -441,7 +441,7 @@ class GitHub
             $used = $item->used;
             $limit = $item->limit;
             $percentage = ($used * 100) / $limit;
-            $minutes = sprintf('%02d', floor(($item->reset - time()) / 60));
+            $minutes = sprintf('%02d', max(0, floor(($item->reset - time()) / 60)));
 
             $colorUsage = "green";
             if ($percentage >= 90) {

--- a/Src/Library/GitHub.php
+++ b/Src/Library/GitHub.php
@@ -441,7 +441,7 @@ class GitHub
             $used = $item->used;
             $limit = $item->limit;
             $percentage = ($used * 100) / $limit;
-            $minutes = floor(($item->reset - time()) / 60);
+            $minutes = sprintf('%02d', floor(($item->reset - time()) / 60));
 
             $colorUsage = "green";
             if ($percentage >= 90) {
@@ -461,7 +461,7 @@ class GitHub
                 $colorMinutes = "yellow";
             }
 
-            $resourceUsage = "<img alt='Resource used' src='https://img.shields.io/badge/" . number_format($percentage, 2, '.', '') . "%25-" . $used . "%2F" . $limit . "_requests-" . $colorUsage . "?style=for-the-badge&labelColor=black' />";
+            $resourceUsage = "<img alt='Resource used' src='https://img.shields.io/badge/" . sprintf('%02.2f', $percentage) . "%25-" . $used . "%2F" . $limit . "_requests-" . $colorUsage . "?style=for-the-badge&labelColor=black' />";
             $resourceReset = "<img alt='Resource reset' src='https://img.shields.io/badge/" . $minutes . "-" . date(self::DATE_TIME_FORMAT, $item->reset) . "-" . $colorMinutes . "?style=for-the-badge&labelColor=black' />";
 
             $data[] = [$resource, $resourceUsage, $resourceReset];


### PR DESCRIPTION
### **User description**
## 📑 Description
Update GitHub.php

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Enhanced the display of API usage information for better readability.
- Updated the percentage calculation to format with two decimal places.
- Improved the visual representation of resource usage in the output.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GitHub.php</strong><dd><code>Enhance API Usage Display Formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Library/GitHub.php
<li>Improved formatting of percentage display in API usage.<br> <li> Updated resource usage badge to show percentage with two decimal <br>places.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/projects-monitor/pull/788/files#diff-82cca199679a768b9fc6dbefa33adffcad8c4adedfcaae85ef5cd9da6109c6ce">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved formatting of GitHub API usage metrics
	- Ensured minutes and percentage values are consistently displayed with two decimal places
	- Prevented negative minute calculations for API reset time

<!-- end of auto-generated comment: release notes by coderabbit.ai -->