### PR TITLE
Add link to HealthChecks.io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,9 +105,9 @@ jobs:
           mkdir -p secrets
           cd secrets
           echo "<?php" >> healthChecksIo.secrets.php
-          echo "\$healthChecksIoReadKeys[] = \"${{ secrets.HEALTHCHECKSIO_RK1 }}\";" >> healthChecksIo.secrets.php
-          echo "\$healthChecksIoReadKeys[] = \"${{ secrets.HEALTHCHECKSIO_RK2 }}\";" >> healthChecksIo.secrets.php
-          echo "\$healthChecksIoReadKeys[] = \"${{ secrets.HEALTHCHECKSIO_RK3 }}\";" >> healthChecksIo.secrets.php
+          echo "\$healthChecksIoWriteKeys[] = \"${{ secrets.HEALTHCHECKSIO_WK1 }}\";" >> healthChecksIo.secrets.php
+          echo "\$healthChecksIoWriteKeys[] = \"${{ secrets.HEALTHCHECKSIO_WK2 }}\";" >> healthChecksIo.secrets.php
+          echo "\$healthChecksIoWriteKeys[] = \"${{ secrets.HEALTHCHECKSIO_WK3 }}\";" >> healthChecksIo.secrets.php
 
       - name: Create Ip2WhoIs secrets file
         if: steps.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'

--- a/Src/Library/HealthChecksIo.php
+++ b/Src/Library/HealthChecksIo.php
@@ -9,7 +9,7 @@ class HealthChecksIo
 {
     private const HEALTH_CHECKS_API_URL = "https://healthchecks.io/api/v3/";
 
-    private $readKeys = array();
+    private $writeKeys = array();
 
     private $request;
 
@@ -18,7 +18,7 @@ class HealthChecksIo
         $config = new Configuration();
         $config->init();
 
-        global $healthChecksIoReadKeys;
+        global $healthChecksIowriteKeys;
 
         if (!file_exists(__DIR__ . "/../secrets/healthChecksIo.secrets.php")) {
             throw new SecretsFileNotFoundException("File not found: healthChecksIo.secrets.php");
@@ -26,15 +26,15 @@ class HealthChecksIo
 
         require_once __DIR__ . "/../secrets/healthChecksIo.secrets.php";
 
-        $this->readKeys = $healthChecksIoReadKeys;
+        $this->writeKeys = $healthChecksIoWriteKeys;
         $this->request = new Request();
     }
 
-    private function getRequest($readKey)
+    private function getRequest($writeKey)
     {
         $url = self::HEALTH_CHECKS_API_URL . "checks/";
         $headers = [
-            "X-Api-Key: {$readKey}",
+            "X-Api-Key: {$writeKey}",
             "Accept: application/json",
             constant("USER_AGENT")
         ];
@@ -77,18 +77,19 @@ class HealthChecksIo
     {
         $checks = array();
 
-        foreach ($this->readKeys as $readKey) {
-            $response = $this->getRequest($readKey);
+        foreach ($this->writeKeys as $writeKey) {
+            $response = $this->getRequest($writeKey);
 
             foreach ($response->checks as $check) {
-
-                $img =
+                $badge =
                     "<img alt='" . $check->name . "' src='https://img.shields.io/badge/" . $this->mapStatus($check->status) .
                     "-" . str_replace("-", "--", $check->name) . "-" . $this->mapColor($check->status) .
                     "?style=for-the-badge&labelColor=white' />";
+                $link = "https://healthchecks.io/checks/{$check->uuid}/details/";
+                $badge = "<a href='{$link}' title='{$check->status}' target='_blank' rel='noopener noreferrer'>{$badge}</a>";
 
                 $checks[] = array(
-                    $img,
+                    $badgeLink,
                     date("H:i:s d/m/Y", $check->last_ping == null ? time() : strtotime($check->last_ping)),
                     date("H:i:s d/m/Y", $check->next_ping == null ? time() : strtotime($check->next_ping))
                 );

--- a/Src/Library/HealthChecksIo.php
+++ b/Src/Library/HealthChecksIo.php
@@ -81,17 +81,18 @@ class HealthChecksIo
             $response = $this->getRequest($writeKey);
 
             foreach ($response->checks as $check) {
-                $badge =
-                    "<img alt='" . $check->name . "' src='https://img.shields.io/badge/" . $this->mapStatus($check->status) .
-                    "-" . str_replace("-", "--", $check->name) . "-" . $this->mapColor($check->status) .
-                    "?style=for-the-badge&labelColor=white' />";
                 $link = "https://healthchecks.io/checks/{$check->uuid}/details/";
+
+                $badge = "<img alt='" . $check->name . "' src='https://img.shields.io/badge/" . $this->mapStatus($check->status);
+                $badge .= "-" . str_replace("-", "--", $check->name) . "-" . $this->mapColor($check->status);
+                $badge .= "?style=for-the-badge&labelColor=white' />";
+
                 $badgeLink = "<a href='{$link}' title='{$check->status}' target='_blank' rel='noopener noreferrer'>{$badge}</a>";
 
                 $checks[] = array(
-                    $badgeLink,
-                    date("H:i:s d/m/Y", $check->last_ping == null ? time() : strtotime($check->last_ping)),
-                    date("H:i:s d/m/Y", $check->next_ping == null ? time() : strtotime($check->next_ping))
+                             $badgeLink,
+                             date("H:i:s d/m/Y", $check->last_ping == null ? time() : strtotime($check->last_ping)),
+                             date("H:i:s d/m/Y", $check->next_ping == null ? time() : strtotime($check->next_ping))
                 );
             }
         }

--- a/Src/Library/HealthChecksIo.php
+++ b/Src/Library/HealthChecksIo.php
@@ -18,7 +18,7 @@ class HealthChecksIo
         $config = new Configuration();
         $config->init();
 
-        global $healthChecksIowriteKeys;
+        global $healthChecksIoWriteKeys;
 
         if (!file_exists(__DIR__ . "/../secrets/healthChecksIo.secrets.php")) {
             throw new SecretsFileNotFoundException("File not found: healthChecksIo.secrets.php");
@@ -86,7 +86,7 @@ class HealthChecksIo
                     "-" . str_replace("-", "--", $check->name) . "-" . $this->mapColor($check->status) .
                     "?style=for-the-badge&labelColor=white' />";
                 $link = "https://healthchecks.io/checks/{$check->uuid}/details/";
-                $badge = "<a href='{$link}' title='{$check->status}' target='_blank' rel='noopener noreferrer'>{$badge}</a>";
+                $badgeLink = "<a href='{$link}' title='{$check->status}' target='_blank' rel='noopener noreferrer'>{$badge}</a>";
 
                 $checks[] = array(
                     $badgeLink,


### PR DESCRIPTION
## 📑 Description
Add link to HealthChecks.io

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Add clickable links to HealthChecks.io badges and update key management from read keys to write keys

Enhancements:
- Modify HealthChecks.io integration to add clickable links to individual check details

CI:
- Update GitHub Actions deployment workflow to use write keys instead of read keys

Chores:
- Rename API keys from 'readKeys' to 'writeKeys' in the HealthChecks.io implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Health check badges now link directly to their detail pages on healthchecks.io, opening in a new tab for easier access.

- **Bug Fixes**
  - Updated integration to use write keys for health checks instead of read keys, ensuring correct functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->