### PR TITLE
Update Ip2WhoIs.php

### DIFF
--- a/Src/Library/Ip2WhoIs.php
+++ b/Src/Library/Ip2WhoIs.php
@@ -50,9 +50,9 @@ class Ip2WhoIs
             "gstraccini.bot",
             "gstraccini.dev",
             "progress-bar.xyz",
-            #"straccini.com",
+            "straccini.com",
             "straccini.com.br",
-            #"stracini.com",
+            "stracini.com",
             "stracini.com.br"
         ];
         $pattern = '/https?:\/\/[^\s]+/';


### PR DESCRIPTION
## Summary by Sourcery

Reenable previously commented domains in the IP-to-WhoIs domain validity list

Bug Fixes:
- Reinstate "straccini.com" in the domain validity array
- Reinstate "stracini.com" in the domain validity array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored domain validity checks for "straccini.com" and "stracini.com", ensuring these domains are now properly included in processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->