### PR TITLE
Update GitHub billing usage api

### DIFF
--- a/Src/Library/GitHub.php
+++ b/Src/Library/GitHub.php
@@ -376,7 +376,7 @@ class GitHub
 
         return $result;
     }
-    
+
     /**
      * Transform new GitHub billing API response to match old format
      */
@@ -386,7 +386,7 @@ class GitHub
         if (isset($rawData->total_minutes_used) || isset($rawData->days_left_in_billing_cycle)) {
             return $rawData;
         }
-    
+
         // Handle new API response format
         if (!isset($rawData->usageItems) || !is_array($rawData->usageItems)) {
             return (object) [
@@ -395,13 +395,13 @@ class GitHub
                 'days_left_in_billing_cycle' => $this->calculateDaysLeftInBillingCycle()
             ];
         }
-    
+
         if ($type === 'actions') {
             return $this->transformActionsData($rawData->usageItems);
         } elseif ($type === 'shared-storage') {
             return $this->transformSharedStorageData($rawData->usageItems);
         }
-    
+
         // Default fallback
         return (object) [
             'total_minutes_used' => 0,
@@ -409,7 +409,7 @@ class GitHub
             'days_left_in_billing_cycle' => $this->calculateDaysLeftInBillingCycle()
         ];
     }
-    
+
     /**
      * Transform GitHub Actions billing data from new format to old format
      */
@@ -419,19 +419,19 @@ class GitHub
         $totalPaidMinutesUsed = 0; // Now represented as $ amount
         $includedMinutes = 0; // Now represented as $ amount via discountAmount
         $minutesUsedBreakdown = [];
-    
+
         foreach ($usageItems as $item) {
             // Filter for Actions minutes only
             if ($item->product === 'Actions' && $item->unitType === 'minutes') {
                 // Sum total minutes used
                 $totalMinutesUsed += $item->quantity;
-                
+
                 // Sum paid minutes (now as dollar amount via netAmount)
                 $totalPaidMinutesUsed += $item->netAmount;
-                
+
                 // Sum included minutes (now as dollar amount via discountAmount)
                 $includedMinutes += $item->discountAmount;
-                
+
                 // Build minutes breakdown by SKU
                 $sku = $item->sku;
                 if (!isset($minutesUsedBreakdown[$sku])) {
@@ -440,7 +440,7 @@ class GitHub
                 $minutesUsedBreakdown[$sku] += $item->quantity;
             }
         }
-    
+
         return (object) [
             'total_minutes_used' => $totalMinutesUsed,
             'total_paid_minutes_used' => $totalPaidMinutesUsed, // Now dollar amount
@@ -449,7 +449,7 @@ class GitHub
             'days_left_in_billing_cycle' => $this->calculateDaysLeftInBillingCycle()
         ];
     }
-    
+
     /**
      * Transform shared storage billing data from new format to old format
      */
@@ -457,7 +457,7 @@ class GitHub
     {
         $estimatedStorageForMonth = 0;
         $estimatedPaidStorageForMonth = 0;
-    
+
         foreach ($usageItems as $item) {
             // Filter for Packages storage
             if ($item->product === 'Packages' && $item->sku === 'Packages storage' && $item->unitType === 'GigabyteHours') {
@@ -465,14 +465,14 @@ class GitHub
                 $estimatedPaidStorageForMonth += $item->netAmount;
             }
         }
-    
+
         return (object) [
             'days_left_in_billing_cycle' => $this->calculateDaysLeftInBillingCycle(),
             'estimated_paid_storage_for_month' => $estimatedPaidStorageForMonth,
             'estimated_storage_for_month' => $estimatedStorageForMonth
         ];
     }
-    
+
     /**
      * Calculate days left in current billing cycle
      * Since this info is no longer provided by the API, we calculate it
@@ -481,7 +481,7 @@ class GitHub
     {
         $currentDay = (int) date('j'); // Day of month without leading zeros
         $daysInMonth = (int) date('t'); // Number of days in current month
-        
+
         return max(0, $daysInMonth - $currentDay);
     }
 

--- a/Src/Library/GitHub.php
+++ b/Src/Library/GitHub.php
@@ -443,8 +443,8 @@ class GitHub
 
         return (object) [
             'total_minutes_used' => $totalMinutesUsed,
-            'total_paid_minutes_used' => $totalPaidMinutesUsed, // Now dollar amount
-            'included_minutes' => $includedMinutes, // Now dollar amount
+            'total_paid_amount'    => $totalPaidMinutesUsed, // Dollar amount
+            'included_amount'      => $includedMinutes,       // Dollar amount
             'minutes_used_breakdown' => (object) $minutesUsedBreakdown,
             'days_left_in_billing_cycle' => $this->calculateDaysLeftInBillingCycle()
         ];

--- a/Src/api/v1/github.php
+++ b/Src/api/v1/github.php
@@ -10,7 +10,7 @@ $apiUsage = $github->getApiUsage();
 ;
 $data["api_usage"] = $apiUsage["data"];
 $data["api_usage_core"] = $apiUsage["core"];
-//$data["accounts_usage"] = $github->getAccountUsage();
+$data["accounts_usage"] = $github->getAccountUsage();
 $data["issues"] = $github->getIssues();
 $data["pull_requests"] = $github->getPullRequests();
 $data["latest_release"] = $github->getLatestReleaseOfBancosBrasileiros();


### PR DESCRIPTION
## 📑 Description
Update GitHub billing usage api

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [X] Yes
- [ ] No

---

## Summary by Sourcery

Update GitHub billing usage handling to support the new API format by transforming usageItems into the old schema, recalculate billing cycle days, and ensure transformed data is used consistently, while reactivating account usage in the v1 endpoint

Enhancements:
- Transform GitHub billing API responses to the legacy format using transformBillingData
- Introduce transformActionsData and transformSharedStorageData to map new usageItems payloads
- Apply billing data transformation for both cached and fresh API responses
- Add calculateDaysLeftInBillingCycle to derive remaining days in the billing cycle

Chores:
- Re-enable accounts_usage in the v1 GitHub API endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated billing information display to ensure compatibility with the latest GitHub billing API changes.
  - Account usage data is now included in the output for improved visibility.

- **Bug Fixes**
  - Billing data is consistently formatted and accurate, regardless of the API response version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->