### PR TITLE
Fix error parser class for single line without file

### DIFF
--- a/Src/Library/LogParser.php
+++ b/Src/Library/LogParser.php
@@ -28,16 +28,19 @@ class LogParser
         \]
         \s
         (?<multilineError>
-            (?:.*?)(?=\s+in\s.+?\.php(?:\son\sline\s|:)\d+)
+            (?:.*?)
+            (?=\s+in\s.+?\.php(?:\son\sline\s|:)\d+|$)
         )
-        \s+in\s(?<file>.+?\.php)
-        (?:\son\sline\s|:)
-        (?<line>\d+)
-        (?:\nStack\strace:\n
-            (?<stackTraceDetails>
-                (?:\#\d+\s.+?\n)*
-            )
-            \s+thrown\sin\s.+?\.php\son\sline\s\d+
+        (?:
+            \s+in\s(?<file>.+?\.php)
+            (?:\son\sline\s|:)
+            (?<line>\d+)
+            (?:\nStack\strace:\n
+                (?<stackTraceDetails>
+                    (?:\#\d+\s.+?\n)*
+                )
+                \s+thrown\sin\s.+?\.php\son\sline\s\d+
+            )?
         )?
     $/msx';
 
@@ -76,8 +79,8 @@ class LogParser
             $entry = [
                 'date' => $match['date'],
                 'multilineError' => trim($match['multilineError']),
-                'file' => $match['file'],
-                'line' => $match['line'],
+                'file' => $match['file'] ?? 'NO FILE',
+                'line' => $match['line'] ?? '-',
             ];
 
             if (isset($match['stackTraceDetails']) && $match['stackTraceDetails'] !== '') {

--- a/Tests/UnitTests/LogParserTest.php
+++ b/Tests/UnitTests/LogParserTest.php
@@ -162,4 +162,3 @@ LOG;
         $this->assertSame('/var/www/html/file.php', $entry2['file']);
         $this->assertSame('42', $entry2['line']);
     }
-}

--- a/Tests/UnitTests/LogParserTest.php
+++ b/Tests/UnitTests/LogParserTest.php
@@ -162,4 +162,5 @@ LOG;
         $this->assertSame('/var/www/html/file.php', $entry2['file']);
         $this->assertSame('42', $entry2['line']);
     }
+    }
 }

--- a/Tests/UnitTests/LogParserTest.php
+++ b/Tests/UnitTests/LogParserTest.php
@@ -162,5 +162,4 @@ LOG;
         $this->assertSame('/var/www/html/file.php', $entry2['file']);
         $this->assertSame('42', $entry2['line']);
     }
-    }
 }

--- a/Tests/UnitTests/LogParserTest.php
+++ b/Tests/UnitTests/LogParserTest.php
@@ -162,3 +162,4 @@ LOG;
         $this->assertSame('/var/www/html/file.php', $entry2['file']);
         $this->assertSame('42', $entry2['line']);
     }
+}

--- a/Tests/UnitTests/LogParserTest.php
+++ b/Tests/UnitTests/LogParserTest.php
@@ -142,5 +142,24 @@ LOG;
         $log = <<<LOG
 [17-May-2025 18:00:00 Europe/Dublin] PHP Fatal error: Error without file info
 [17-May-2025 18:01:00 Europe/Dublin] PHP Fatal error: Error with file info in /var/www/html/file.php on line 42
-}
+LOG;
+
+        $results = $this->parser->parse($log);
+
+        $this->assertCount(2, $results);
+
+        // First entry without file info
+        $entry1 = $results[0];
+        $this->assertSame('17-May-2025 18:00:00 Europe/Dublin', $entry1['date']);
+        $this->assertStringContainsString('Error without file info', $entry1['multilineError']);
+        $this->assertSame('NO FILE', $entry1['file']);
+        $this->assertSame('-', $entry1['line']);
+
+        // Second entry with file info
+        $entry2 = $results[1];
+        $this->assertSame('17-May-2025 18:01:00 Europe/Dublin', $entry2['date']);
+        $this->assertStringContainsString('Error with file info', $entry2['multilineError']);
+        $this->assertSame('/var/www/html/file.php', $entry2['file']);
+        $this->assertSame('42', $entry2['line']);
+    }
 }

--- a/Tests/UnitTests/LogParserTest.php
+++ b/Tests/UnitTests/LogParserTest.php
@@ -143,3 +143,4 @@ LOG;
 [17-May-2025 18:00:00 Europe/Dublin] PHP Fatal error: Error without file info
 [17-May-2025 18:01:00 Europe/Dublin] PHP Fatal error: Error with file info in /var/www/html/file.php on line 42
 }
+}


### PR DESCRIPTION
## 📑 Description
Fix error parser class for single line without file

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Bug Fixes:
- Make file, line, and stack-trace capture optional in the regex and default missing file to 'NO FILE' and line to '-'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log parsing to handle error entries that lack file and line information, ensuring such entries are still captured and displayed with default placeholder values.

* **Tests**
  * Added tests to verify correct parsing of log entries without file and line details, including both single-line and multi-line error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->