### PR TITLE
Hide truncate button when no data, show when data exists

### DIFF
--- a/Src/index.php
+++ b/Src/index.php
@@ -159,7 +159,7 @@ $configuration = new Configuration();
          </div>
          <div class="chart-container">
             <div class="text-end mb-1">
-               <button id="btn_truncate_messages" class="btn btn-warning btn-sm" onclick="if(window.confirmTruncateMessages?.()) window.truncateMessages?.()">Truncate All Messages</button>
+               <button id="btn_truncate_messages" class="btn btn-warning btn-sm" style="display:none" onclick="if(window.confirmTruncateMessages?.()) window.truncateMessages?.()">Truncate All Messages</button>
             </div>
             <div id="messages_by_applications"></div>
          </div>

--- a/Src/static/dataDisplay.js
+++ b/Src/static/dataDisplay.js
@@ -304,12 +304,16 @@ export class DataDisplayManager {
     );
     this.chartManager.drawPieChart(response.byApplications, "pie_chart_2", optionsByApplications);
 
+    const truncateBtn = document.getElementById("btn_truncate_messages");
+
     if (response.byApplications.length === 1) {
+      if (truncateBtn) truncateBtn.style.display = "none";
       this.chartManager.drawDataTable([[]], "messages_by_applications", CHART_OPTIONS.table);
       return;
     }
 
     if (response.byApplications.length > 1) {
+      if (truncateBtn) truncateBtn.style.display = "";
       const byApplicationsTableData = response.byApplications;
       byApplicationsTableData[0].unshift("Actions");
       for (let i = 1; i < byApplicationsTableData.length; i++) {


### PR DESCRIPTION
## 📑 Description
The button starts hidden and is only revealed when `byApplications` has more than one entry, preventing it from appearing on empty or single-entry states.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * "Truncate All Messages" button is now hidden by default and intelligently displayed based on the number of applications in your message view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/projects-monitor/pull/1102)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->