### PR TITLE
Add error_log processing daemon and CPanel file ops +semver: minor

### DIFF
--- a/Sql/0012.add_unique_index_errors_table.sql
+++ b/Sql/0012.add_unique_index_errors_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `errors`
+    ADD UNIQUE INDEX `idx_errors_unique` (`error_log_path`(191), `date`, `file`(191), `line`);

--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -415,7 +415,97 @@ class CPanel
         try {
             $response = $this->getRequest("json-api", "cpanel", $parameters);
             return isset($response->cpanelresult->data[0]->result) === true && $response->cpanelresult->data[0]->result === 1;
-        } catch (RequestException $e) {
+        } catch (RequestException) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the full path, dirname, and basename of every error_log file found,
+     * excluding files inside .trash directories and any already-locked .processing files.
+     *
+     * @return array<int, array{fullPath: string, dirname: string, basename: string}>
+     */
+    public function getErrorLogFilePaths(): array
+    {
+        $result = array();
+        $items = $this->searchFiles("error_log", "/");
+
+        foreach ($items as $item) {
+            if (strpos($item->file, ".trash") !== false) {
+                continue;
+            }
+            if (str_ends_with($item->file, ".processing")) {
+                continue;
+            }
+            $pathInfo = pathinfo($item->file);
+            $result[] = array(
+                "fullPath" => $item->file,
+                "dirname"  => $pathInfo["dirname"],
+                "basename" => $pathInfo["basename"]
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reads and returns the raw contents of a file by its full server path.
+     *
+     * @param string $fullPath Absolute path on the cPanel server.
+     * @return array{fullPath: string, dirname: string, basename: string, contents: string}|null
+     */
+    public function readFile(string $fullPath): array|null
+    {
+        return $this->loadContent($fullPath);
+    }
+
+    /**
+     * Renames a file on the cPanel server using the Fileman fileop API.
+     *
+     * @param string $sourcePath Absolute path of the file to rename.
+     * @param string $destPath   Absolute path of the new name/location.
+     * @return bool True on success, false otherwise.
+     */
+    public function renameFile(string $sourcePath, string $destPath): bool
+    {
+        $parameters = array(
+            "cpanel_jsonapi_module" => "Fileman",
+            "cpanel_jsonapi_func"   => "fileop",
+            "cpanel_jsonapi_apiversion" => "2",
+            "op"          => "rename",
+            "sourcefiles" => $sourcePath,
+            "destfiles"   => $destPath
+        );
+
+        try {
+            $response = $this->getRequest("json-api", "cpanel", $parameters);
+            return isset($response->cpanelresult->data[0]->result) && $response->cpanelresult->data[0]->result === 1;
+        } catch (RequestException) {
+            return false;
+        }
+    }
+
+    /**
+     * Moves a file to the cPanel trash by its full server path.
+     *
+     * @param string $fullPath Absolute path of the file to delete.
+     * @return bool True on success, false otherwise.
+     */
+    public function deleteFile(string $fullPath): bool
+    {
+        $parameters = array(
+            "cpanel_jsonapi_module" => "Fileman",
+            "cpanel_jsonapi_func"   => "fileop",
+            "cpanel_jsonapi_apiversion" => "2",
+            "op"          => "trash",
+            "sourcefiles" => $fullPath
+        );
+
+        try {
+            $response = $this->getRequest("json-api", "cpanel", $parameters);
+            return isset($response->cpanelresult->data[0]->result) && $response->cpanelresult->data[0]->result === 1;
+        } catch (RequestException) {
             return false;
         }
     }

--- a/Src/Library/ErrorLog.php
+++ b/Src/Library/ErrorLog.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuiBranco\ProjectsMonitor\Library;
+
+class ErrorLog
+{
+    private \mysqli $connection;
+
+    public function __construct()
+    {
+        $this->connection = (new Database())->getConnection();
+    }
+
+    /**
+     * Returns true when an entry with the same path, date, file, and line already exists,
+     * preventing duplicate rows for the same error occurrence.
+     */
+    private function isDuplicate(string $errorLogPath, string $date, string $file, int $line): bool
+    {
+        $sql = "SELECT id FROM errors WHERE error_log_path = ? AND date = ? AND file = ? AND line = ? LIMIT 1";
+        $stmt = $this->connection->prepare($sql);
+        $stmt->bind_param("sssi", $errorLogPath, $date, $file, $line);
+        $stmt->execute();
+        $stmt->store_result();
+        $found = $stmt->num_rows > 0;
+        $stmt->close();
+        return $found;
+    }
+
+    /**
+     * Inserts a parsed error entry into the errors table.
+     * Returns false without querying the DB when the entry is a duplicate.
+     *
+     * @param string      $errorLogPath     Full server path of the source error_log file.
+     * @param string      $date             MySQL datetime string (Y-m-d H:i:s).
+     * @param string      $error            First line of the error message.
+     * @param string      $errorMultiline   Full (potentially multiline) error message.
+     * @param string      $file             PHP file where the error occurred.
+     * @param int         $line             Line number where the error occurred.
+     * @param string|null $stackTrace       Stack trace summary line, if captured.
+     * @param string|null $stackTraceDetails Numbered stack frames (#0, #1 …), if captured.
+     * @return bool True if a new row was inserted, false if duplicate or on failure.
+     */
+    public function saveError(
+        string $errorLogPath,
+        string $date,
+        string $error,
+        string $errorMultiline,
+        string $file,
+        int $line,
+        ?string $stackTrace,
+        ?string $stackTraceDetails
+    ): bool {
+        if ($this->isDuplicate($errorLogPath, $date, $file, $line)) {
+            return false;
+        }
+
+        $sql = "INSERT INTO errors
+                    (error_log_path, date, error, error_multiline, file, line, stack_trace, stack_trace_details)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        $stmt = $this->connection->prepare($sql);
+        $stmt->bind_param(
+            "sssssiss",
+            $errorLogPath,
+            $date,
+            $error,
+            $errorMultiline,
+            $file,
+            $line,
+            $stackTrace,
+            $stackTraceDetails
+        );
+        $result = $stmt->execute();
+        $stmt->close();
+        return $result;
+    }
+
+    public function getTotal(): int
+    {
+        $total = 0;
+        $stmt = $this->connection->prepare("SELECT COUNT(1) FROM errors");
+        $stmt->execute();
+        $stmt->bind_result($total);
+        $stmt->fetch();
+        $stmt->close();
+        return $total;
+    }
+}

--- a/Src/Worker/ProcessErrorLogs.php
+++ b/Src/Worker/ProcessErrorLogs.php
@@ -1,0 +1,176 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * ProcessErrorLogs — worker that polls cPanel for error_log files, parses them,
+ * persists the entries to the `errors` DB table, and removes the processed files.
+ *
+ * Recommended cron entry (every 5 minutes, adjust path to match your deployment):
+ *
+ *   *\/5 * * * * php /home/<username>/public_html/Src/Worker/ProcessErrorLogs.php \
+ *       >> /var/log/projects-monitor-error-logs.log 2>&1
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit(1);
+}
+
+define('WORKER_START', microtime(true));
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use GuiBranco\ProjectsMonitor\Library\CPanel;
+use GuiBranco\ProjectsMonitor\Library\ErrorLog;
+use GuiBranco\ProjectsMonitor\Library\LogParser;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function workerLog(string $message): void
+{
+    echo '[' . date('Y-m-d H:i:s') . '] ' . $message . PHP_EOL;
+}
+
+function extractFirstLine(string $text): string
+{
+    $nl = strpos($text, "\n");
+    return $nl === false ? trim($text) : trim(substr($text, 0, $nl));
+}
+
+function parseDate(string $raw): ?string
+{
+    try {
+        return (new DateTimeImmutable($raw))->format('Y-m-d H:i:s');
+    } catch (Throwable) {
+        return null;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+$stats = ['files' => 0, 'processed' => 0, 'inserted' => 0, 'skipped' => 0, 'errors' => 0];
+
+workerLog('=== ProcessErrorLogs worker started ===');
+
+try {
+    $cPanel   = new CPanel();
+    $errorLog = new ErrorLog();
+    $parser   = new LogParser();
+} catch (Throwable $e) {
+    workerLog('FATAL: could not initialise services — ' . $e->getMessage());
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Discover files
+// ---------------------------------------------------------------------------
+
+try {
+    $files = $cPanel->getErrorLogFilePaths();
+} catch (Throwable $e) {
+    workerLog('FATAL: could not query cPanel for error_log files — ' . $e->getMessage());
+    exit(1);
+}
+
+$stats['files'] = count($files);
+workerLog("Found {$stats['files']} error_log file(s)");
+
+// ---------------------------------------------------------------------------
+// Process each file
+// ---------------------------------------------------------------------------
+
+foreach ($files as $fileInfo) {
+    $fullPath       = $fileInfo['fullPath'];
+    $processingPath = $fullPath . '.processing';
+
+    workerLog("→ {$fullPath}");
+
+    // Step 1 — rename to lock the file against concurrent cron runs
+    if (!$cPanel->renameFile($fullPath, $processingPath)) {
+        workerLog("  WARN: rename failed, skipping");
+        $stats['errors']++;
+        continue;
+    }
+
+    // Step 2 — read the locked copy
+    $content = $cPanel->readFile($processingPath);
+    if ($content === null || trim($content['contents']) === '') {
+        workerLog("  WARN: file is empty or unreadable, deleting");
+        $cPanel->deleteFile($processingPath);
+        $stats['errors']++;
+        continue;
+    }
+
+    // Step 3 — parse
+    try {
+        $entries = $parser->parse($content['contents']);
+    } catch (Throwable $e) {
+        workerLog("  ERROR: parse failed — " . $e->getMessage() . ", deleting");
+        $cPanel->deleteFile($processingPath);
+        $stats['errors']++;
+        continue;
+    }
+
+    workerLog("  Parsed " . count($entries) . " entr(ies)");
+
+    // Step 4 — persist each entry
+    foreach ($entries as $entry) {
+        $mysqlDate = parseDate($entry['date']);
+        if ($mysqlDate === null) {
+            workerLog("  WARN: unparseable date '{$entry['date']}', skipping entry");
+            $stats['skipped']++;
+            continue;
+        }
+
+        $line             = is_numeric($entry['line']) ? (int) $entry['line'] : 0;
+        $error            = extractFirstLine($entry['multilineError']);
+        $stackTraceDetails = isset($entry['stackTraceDetails']) ? trim($entry['stackTraceDetails']) : null;
+
+        $saved = $errorLog->saveError(
+            $fullPath,             // original path (before rename) as the stable key
+            $mysqlDate,
+            $error,
+            $entry['multilineError'],
+            $entry['file'],
+            $line,
+            null,                  // stack_trace summary not captured by LogParser
+            $stackTraceDetails
+        );
+
+        if ($saved) {
+            $stats['inserted']++;
+        } else {
+            $stats['skipped']++;   // duplicate or DB failure
+        }
+    }
+
+    // Step 5 — delete the processed file
+    if ($cPanel->deleteFile($processingPath)) {
+        workerLog("  Deleted {$processingPath}");
+        $stats['processed']++;
+    } else {
+        workerLog("  WARN: could not delete {$processingPath}");
+        $stats['errors']++;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+$elapsed = round(microtime(true) - WORKER_START, 2);
+workerLog(sprintf(
+    '=== Done in %ss | files: %d  processed: %d  inserted: %d  skipped: %d  errors: %d ===',
+    $elapsed,
+    $stats['files'],
+    $stats['processed'],
+    $stats['inserted'],
+    $stats['skipped'],
+    $stats['errors']
+));


### PR DESCRIPTION
## 📑 Description
Introduce a cron-safe worker (ProcessErrorLogs) that discovers error_log files via cPanel, renames each to a .processing lock, parses entries with LogParser, persists them to the errors table (deduplication via unique index), and deletes the file when done.

Add CPanel methods: getErrorLogFilePaths, readFile, renameFile, deleteFile. Add ErrorLog library for DB persistence. Add SQL migration for the unique index on the errors table.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic error log processing and database storage enabled
  * Duplicate error entry prevention implemented
  * Error log file management capabilities added, including read, rename, and delete operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/projects-monitor/pull/1103)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->