### PR TITLE
feature: add website footer linking to GitHub project

### DIFF
--- a/Src/index.php
+++ b/Src/index.php
@@ -382,6 +382,12 @@ $configuration = new Configuration();
       </div>
    </div>
 
+   <footer class="text-center py-3 mt-2 text-muted small">
+      <a href="https://github.com/guibranco/projects-monitor" target="_blank" rel="noopener noreferrer" class="text-muted text-decoration-none">
+         <i class="bi bi-github me-1"></i>guibranco/projects-monitor
+      </a>
+   </footer>
+
    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       integrity="sha256-CDOy6cOibCWEdsRiZuaHf8dSGGJRYuBGC+mjoJimHGw=" crossorigin="anonymous"></script>
    <script src="https://www.gstatic.com/charts/loader.js"></script>

--- a/Src/login.php
+++ b/Src/login.php
@@ -254,6 +254,12 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
         </div>
     </div>
 
+    <footer class="text-center py-3 mt-2 text-muted small">
+        <a href="https://github.com/guibranco/projects-monitor" target="_blank" rel="noopener noreferrer" class="text-muted text-decoration-none">
+            <i class="fab fa-github me-1"></i>guibranco/projects-monitor
+        </a>
+    </footer>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha256-CDOy6cOibCWEdsRiZuaHf8dSGGJRYuBGC+mjoJimHGw=" crossorigin="anonymous"></script>
     <script>

--- a/Src/recover.php
+++ b/Src/recover.php
@@ -182,6 +182,12 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
             </div>
         </div>
     </div>
+
+    <footer class="text-center py-3 mt-2 text-muted small">
+        <a href="https://github.com/guibranco/projects-monitor" target="_blank" rel="noopener noreferrer" class="text-muted text-decoration-none">
+            <i class="fab fa-github me-1"></i>guibranco/projects-monitor
+        </a>
+    </footer>
 </body>
 
 </html>

--- a/Src/reset.php
+++ b/Src/reset.php
@@ -115,6 +115,12 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
             </div>
         </div>
     </div>
+    <footer class="text-center py-3 mt-2 text-muted small">
+        <a href="https://github.com/guibranco/projects-monitor" target="_blank" rel="noopener noreferrer" class="text-muted text-decoration-none">
+            <i class="fab fa-github me-1"></i>guibranco/projects-monitor
+        </a>
+    </footer>
+
     <script>
         function validatePasswords() {
             const password = document.getElementById('password').value;


### PR DESCRIPTION
## 📑 Description
Add a footer section to multiple pages including index.php, login.php, recover.php, and reset.php. The footer contains a link to the GitHub repository for the project `guibranco/projects-monitor`. This change aims to provide users with easy access to the project's source code and encourage community contribution.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

New Features:
- Display a GitHub repository link in the footer on the index, login, password recovery, and password reset pages.