### PR TITLE
fix: exit gracefully if no error_log files found

### DIFF
--- a/Src/Worker/ProcessErrorLogs.php
+++ b/Src/Worker/ProcessErrorLogs.php
@@ -79,6 +79,11 @@ try {
 }
 
 $stats['files'] = count($files);
+
+if ($stats['files'] === 0) {
+    exit(0);
+}
+
 workerLog("Found {$stats['files']} error_log file(s)");
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 📑 Description
Add a condition to exit the script early if no error_log files are found. This change prevents unnecessary processing and logs a message indicating the absence of files. The modification helps to optimize performance by avoiding running further steps when there are no files to process.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Bug Fixes:
- Prevent running the error log processing workflow when there are zero files to process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error log processing efficiency by implementing early termination when no error log files are present, reducing unnecessary operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/projects-monitor/pull/1109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->