### PR TITLE
refactor: extract footer into a separate PHP file

### DIFF
--- a/Src/footer.php
+++ b/Src/footer.php
@@ -1,0 +1,5 @@
+<footer class="text-center py-3 mt-2 text-muted small">
+    <a href="https://github.com/guibranco/projects-monitor" target="_blank" rel="noopener noreferrer" class="text-muted text-decoration-none">
+        <i class="bi bi-github me-1"></i>guibranco/projects-monitor
+    </a>
+</footer>

--- a/Src/index.php
+++ b/Src/index.php
@@ -382,11 +382,7 @@ $configuration = new Configuration();
       </div>
    </div>
 
-   <footer class="text-center py-3 mt-2 text-muted small">
-      <a href="https://github.com/guibranco/projects-monitor" target="_blank" rel="noopener noreferrer" class="text-muted text-decoration-none">
-         <i class="bi bi-github me-1"></i>guibranco/projects-monitor
-      </a>
-   </footer>
+   <?php include_once __DIR__ . '/footer.php'; ?>
 
    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       integrity="sha256-CDOy6cOibCWEdsRiZuaHf8dSGGJRYuBGC+mjoJimHGw=" crossorigin="anonymous"></script>

--- a/Src/login.php
+++ b/Src/login.php
@@ -89,6 +89,7 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <link rel="stylesheet" href="static/styles-public.css?<?php echo filemtime("static/styles-public.css"); ?>">
 </head>
 
@@ -254,11 +255,7 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
         </div>
     </div>
 
-    <footer class="text-center py-3 mt-2 text-muted small">
-        <a href="https://github.com/guibranco/projects-monitor" target="_blank" rel="noopener noreferrer" class="text-muted text-decoration-none">
-            <i class="fab fa-github me-1"></i>guibranco/projects-monitor
-        </a>
-    </footer>
+    <?php include_once __DIR__ . '/footer.php'; ?>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha256-CDOy6cOibCWEdsRiZuaHf8dSGGJRYuBGC+mjoJimHGw=" crossorigin="anonymous"></script>

--- a/Src/recover.php
+++ b/Src/recover.php
@@ -149,6 +149,7 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <link rel="stylesheet" href="static/styles-public.css?<?php echo filemtime("static/styles-public.css"); ?>">
 </head>
 
@@ -183,11 +184,7 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
         </div>
     </div>
 
-    <footer class="text-center py-3 mt-2 text-muted small">
-        <a href="https://github.com/guibranco/projects-monitor" target="_blank" rel="noopener noreferrer" class="text-muted text-decoration-none">
-            <i class="fab fa-github me-1"></i>guibranco/projects-monitor
-        </a>
-    </footer>
+    <?php include_once __DIR__ . '/footer.php'; ?>
 </body>
 
 </html>

--- a/Src/reset.php
+++ b/Src/reset.php
@@ -78,6 +78,7 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <link rel="stylesheet" href="static/styles-public.css?<?php echo filemtime("static/styles-public.css"); ?>">
 </head>
 
@@ -115,11 +116,7 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
             </div>
         </div>
     </div>
-    <footer class="text-center py-3 mt-2 text-muted small">
-        <a href="https://github.com/guibranco/projects-monitor" target="_blank" rel="noopener noreferrer" class="text-muted text-decoration-none">
-            <i class="fab fa-github me-1"></i>guibranco/projects-monitor
-        </a>
-    </footer>
+    <?php include_once __DIR__ . '/footer.php'; ?>
 
     <script>
         function validatePasswords() {


### PR DESCRIPTION
## 📑 Description
Create `footer.php` to centralize the footer HTML and include it across multiple pages. This enhances maintainability by enabling updates to the footer in a single location. The change reduces duplication and simplifies updates to the footer, preventing inconsistencies. All pages (index.php, login.php, recover.php, and reset.php) now include the footer using `include_once`. Added bootstrap-icons to login, recover, and reset pages to ensure icons display correctly.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Extract the shared footer markup into a reusable PHP partial and update all public pages to include it.

Enhancements:
- Introduce a centralized footer.php partial and replace duplicated inline footer HTML in index, login, recover, and reset pages with an include.
- Add the Bootstrap Icons stylesheet to the login, recover, and reset pages to ensure consistent icon rendering with the shared footer.