### PR TITLE
fix: update Content-Security-Policy and add footer styling

### DIFF
--- a/Src/recover.php
+++ b/Src/recover.php
@@ -6,7 +6,7 @@ use GuiBranco\ProjectsMonitor\Library\Configuration;
 use GuiBranco\ProjectsMonitor\Library\Database;
 use GuiBranco\ProjectsMonitor\Library\Logger;
 
-header("Content-Security-Policy: default-src 'self' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;");
+header("Content-Security-Policy: default-src 'self' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net;");
 header("X-Content-Type-Options: nosniff");
 header("X-Frame-Options: DENY");
 header("Referrer-Policy: strict-origin-when-cross-origin");

--- a/Src/reset.php
+++ b/Src/reset.php
@@ -5,7 +5,7 @@ require_once 'vendor/autoload.php';
 use GuiBranco\ProjectsMonitor\Library\Configuration;
 use GuiBranco\ProjectsMonitor\Library\Database;
 
-header("Content-Security-Policy: default-src 'self' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net;");
+header("Content-Security-Policy: default-src 'self' https://cdn.jsdelivr.net; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net;");
 header("X-Content-Type-Options: nosniff");
 header("X-Frame-Options: DENY");
 header("Referrer-Policy: strict-origin-when-cross-origin");

--- a/Src/static/styles-public.css
+++ b/Src/static/styles-public.css
@@ -94,6 +94,10 @@
   }
 }
 
+footer {
+  border-top: 1px solid #dee2e6;
+}
+
 .tech-badge {
   background-color: #f8f9fa;
   color: #6c757d;

--- a/Src/static/styles.css
+++ b/Src/static/styles.css
@@ -644,3 +644,18 @@ code {
     padding: 0;
   }
 }
+
+/* ===========================================
+   FOOTER
+   =========================================== */
+footer {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+footer a {
+  color: rgba(255, 255, 255, 0.45) !important;
+}
+
+footer a:hover {
+  color: rgba(255, 255, 255, 0.8) !important;
+}


### PR DESCRIPTION
## 📑 Description
Extend the Content-Security-Policy headers in recover.php and reset.php to include font source permissions, improving page security.

Introduce styling changes for the footer in styles-public.css and styles.css, giving it visual differentiation with a top border and specifying text/link colors to enhance design consistency across the site.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Update security headers and footer styling for recovery and reset pages.

New Features:
- Add footer color styling for text and links in the main stylesheet.
- Add a top border style for the footer in the public stylesheet.

Enhancements:
- Extend Content-Security-Policy on recover and reset pages to allow loading fonts from the jsDelivr CDN.