### PR TITLE
feat: implement caching for public stats API +semver: minor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/cache/**
+!**/cache/.htaccess
 **/secrets/**
 **/vendor/**
 **/domains.json

--- a/Src/Library/PublicStats.php
+++ b/Src/Library/PublicStats.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuiBranco\ProjectsMonitor\Library;
+
+class PublicStats
+{
+    public const CACHE_FILE = __DIR__ . '/../cache/public-stats.json';
+    public const CACHE_TTL  = 600; // seconds — 10 minutes
+
+    public static function generate(): array
+    {
+        $upStats     = null;
+        $hcStats     = null;
+        $cpanelUsage = null;
+        $dbConnected = false;
+
+        try {
+            $upStats = (new UpTimeRobot())->getStats();
+        } catch (\Throwable) {
+        }
+
+        try {
+            $hcStats = (new HealthChecksIo())->getStats();
+        } catch (\Throwable) {
+        }
+
+        try {
+            $cpanelUsage = (new CPanel())->getUsageData();
+        } catch (\Throwable) {
+        }
+
+        try {
+            $dbConnected = (new Database())->getConnection() !== null;
+        } catch (\Throwable) {
+        }
+
+        $totalMonitors = 0;
+        $totalUp       = 0;
+        $totalWarning  = 0;
+        $totalDown     = 0;
+
+        if ($upStats !== null) {
+            $totalMonitors += $upStats['counts']['total'];
+            $totalUp       += $upStats['counts']['up'];
+            $totalWarning  += $upStats['counts']['warning'];
+            $totalDown     += $upStats['counts']['down'];
+        }
+
+        if ($hcStats !== null) {
+            $totalMonitors += $hcStats['counts']['total'];
+            $totalUp       += $hcStats['counts']['up'];
+            $totalWarning  += $hcStats['counts']['warning'];
+            $totalDown     += $hcStats['counts']['down'];
+        }
+
+        $allActivity = array_merge($upStats['monitors'] ?? [], $hcStats['checks'] ?? []);
+        usort($allActivity, static function ($a, $b) {
+            if ($a['lastChange'] === null && $b['lastChange'] === null) return 0;
+            if ($a['lastChange'] === null) return 1;
+            if ($b['lastChange'] === null) return -1;
+            return strcmp($b['lastChange'], $a['lastChange']);
+        });
+
+        $cpuData       = null;
+        $memoryData    = null;
+        $processesData = null;
+
+        if ($cpanelUsage !== null) {
+            foreach ($cpanelUsage as $item) {
+                match ($item['id']) {
+                    'lvecpu'    => $cpuData       = $item,
+                    'lvememphy' => $memoryData    = $item,
+                    'lvenproc'  => $processesData = $item,
+                    default     => null,
+                };
+            }
+        }
+
+        return [
+            'monitors' => [
+                'total'    => $totalMonitors,
+                'healthy'  => $totalUp,
+                'warning'  => $totalWarning,
+                'critical' => $totalDown,
+            ],
+            'recentActivity' => array_slice($allActivity, 0, 5),
+            'systemStatus' => [
+                'cpu'       => self::resourceEntry($cpuData,       $cpuData['description']       ?? 'CPU'),
+                'memory'    => self::resourceEntry($memoryData,    $memoryData['description']    ?? 'Memory'),
+                'processes' => self::resourceEntry($processesData, $processesData['description'] ?? 'Processes'),
+                'database'  => ['status' => $dbConnected ? 'operational' : 'critical', 'percent' => null, 'label' => 'Database'],
+            ],
+            'performance' => [
+                'cpu'       => self::performanceEntry($cpuData,       '%'),
+                'memory'    => self::performanceEntry($memoryData,    'MB'),
+                'processes' => self::performanceEntry($processesData, ''),
+            ],
+            'generatedAt' => gmdate('Y-m-d\TH:i:s\Z'),
+        ];
+    }
+
+    private static function resourceStatus(?array $item): string
+    {
+        if ($item === null || $item['maximum'] == 0) return 'unknown';
+        $pct = ($item['usage'] / $item['maximum']) * 100;
+        if ($pct >= 90) return 'critical';
+        if ($pct >= 75) return 'warning';
+        return 'operational';
+    }
+
+    private static function resourcePercent(?array $item): ?float
+    {
+        if ($item === null || $item['maximum'] == 0) return null;
+        return round(($item['usage'] / $item['maximum']) * 100, 1);
+    }
+
+    private static function resourceEntry(?array $item, string $label): array
+    {
+        return ['status' => self::resourceStatus($item), 'percent' => self::resourcePercent($item), 'label' => $label];
+    }
+
+    private static function performanceEntry(?array $item, string $unit): array
+    {
+        return [
+            'value'   => $item ? (float)$item['usage']   : null,
+            'max'     => $item ? (float)$item['maximum']  : null,
+            'percent' => self::resourcePercent($item),
+            'unit'    => $unit,
+        ];
+    }
+}

--- a/Src/Worker/GeneratePublicStats.php
+++ b/Src/Worker/GeneratePublicStats.php
@@ -1,0 +1,46 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * GeneratePublicStats — worker that pre-computes the public dashboard stats
+ * and writes them to a JSON cache file consumed by api/v1/public-stats.php.
+ *
+ * Recommended cron entry (every 5 minutes):
+ *
+ *   *\/5 * * * * php /home/<username>/public_html/Src/Worker/GeneratePublicStats.php \
+ *       >> /var/log/projects-monitor-public-stats.log 2>&1
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit(1);
+}
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use GuiBranco\ProjectsMonitor\Library\PublicStats;
+
+$cacheFile = PublicStats::CACHE_FILE;
+$cacheDir  = dirname($cacheFile);
+
+if (!is_dir($cacheDir) && !mkdir($cacheDir, 0755, true)) {
+    fwrite(STDERR, '[' . date('Y-m-d H:i:s') . '] ERROR: could not create cache directory ' . $cacheDir . PHP_EOL);
+    exit(1);
+}
+
+$data = PublicStats::generate();
+$json = json_encode($data, JSON_UNESCAPED_UNICODE);
+
+if ($json === false) {
+    fwrite(STDERR, '[' . date('Y-m-d H:i:s') . '] ERROR: json_encode failed — ' . json_last_error_msg() . PHP_EOL);
+    exit(1);
+}
+
+if (file_put_contents($cacheFile, $json, LOCK_EX) === false) {
+    fwrite(STDERR, '[' . date('Y-m-d H:i:s') . '] ERROR: could not write cache file ' . $cacheFile . PHP_EOL);
+    exit(1);
+}
+
+exit(0);

--- a/Src/api/v1/public-stats.php
+++ b/Src/api/v1/public-stats.php
@@ -2,150 +2,23 @@
 
 require_once '../../vendor/autoload.php';
 
-use GuiBranco\ProjectsMonitor\Library\CPanel;
-use GuiBranco\ProjectsMonitor\Library\Database;
-use GuiBranco\ProjectsMonitor\Library\HealthChecksIo;
-use GuiBranco\ProjectsMonitor\Library\UpTimeRobot;
+use GuiBranco\ProjectsMonitor\Library\PublicStats;
 
 header('Content-Type: application/json; charset=utf-8');
 header('Cache-Control: public, max-age=60');
 header('Access-Control-Allow-Origin: *');
 
-$upStats     = null;
-$hcStats     = null;
-$cpanelUsage = null;
-$dbConnected = false;
+$cacheFile = PublicStats::CACHE_FILE;
 
-try {
-    $upTimeRobot = new UpTimeRobot();
-    $upStats     = $upTimeRobot->getStats();
-} catch (Throwable) {
-    // service unavailable – skip
-}
-
-try {
-    $healthChecksIo = new HealthChecksIo();
-    $hcStats        = $healthChecksIo->getStats();
-} catch (Throwable) {
-    // service unavailable – skip
-}
-
-try {
-    $cPanel      = new CPanel();
-    $cpanelUsage = $cPanel->getUsageData();
-} catch (Throwable) {
-    // service unavailable – skip
-}
-
-try {
-    $db          = new Database();
-    $conn        = $db->getConnection();
-    $dbConnected = $conn !== null;
-} catch (Throwable) {
-    // service unavailable – skip
-}
-
-// ── Aggregate monitor counts across both services ────────────────────────────
-
-$totalMonitors  = 0;
-$totalUp        = 0;
-$totalWarning   = 0;
-$totalDown      = 0;
-
-if ($upStats !== null) {
-    $totalMonitors += $upStats['counts']['total'];
-    $totalUp       += $upStats['counts']['up'];
-    $totalWarning  += $upStats['counts']['warning'];
-    $totalDown     += $upStats['counts']['down'];
-}
-
-if ($hcStats !== null) {
-    $totalMonitors += $hcStats['counts']['total'];
-    $totalUp       += $hcStats['counts']['up'];
-    $totalWarning  += $hcStats['counts']['warning'];
-    $totalDown     += $hcStats['counts']['down'];
-}
-
-// ── Recent activity: merge monitors + checks, keep last 5 by most recent change ──
-
-$allActivity = array_merge(
-    $upStats['monitors'] ?? [],
-    $hcStats['checks']   ?? []
-);
-
-usort($allActivity, function ($a, $b) {
-    // Items without a lastChange go to the bottom
-    if ($a['lastChange'] === null && $b['lastChange'] === null) return 0;
-    if ($a['lastChange'] === null) return 1;
-    if ($b['lastChange'] === null) return -1;
-    return strcmp($b['lastChange'], $a['lastChange']);
-});
-
-$recentActivity = array_slice($allActivity, 0, 5);
-
-// ── System status derived from CPanel resource usage ────────────────────────
-
-$cpuData       = null;
-$memoryData    = null;
-$processesData = null;
-
-if ($cpanelUsage !== null) {
-    foreach ($cpanelUsage as $item) {
-        switch ($item['id']) {
-            case 'lvecpu':
-                $cpuData = $item;
-                break;
-            case 'lvememphy':
-                $memoryData = $item;
-                break;
-            case 'lvenproc':
-                $processesData = $item;
-                break;
-        }
+if (
+    file_exists($cacheFile) &&
+    (time() - filemtime($cacheFile)) < PublicStats::CACHE_TTL
+) {
+    $cached = file_get_contents($cacheFile);
+    if ($cached !== false) {
+        echo $cached;
+        exit;
     }
 }
 
-function resourceStatus(array|null $item): string
-{
-    if ($item === null || $item['maximum'] == 0) {
-        return 'unknown';
-    }
-    $pct = ($item['usage'] / $item['maximum']) * 100;
-    if ($pct >= 90) return 'critical';
-    if ($pct >= 75) return 'warning';
-    return 'operational';
-}
-
-function resourcePercent(array|null $item): float|null
-{
-    if ($item === null || $item['maximum'] == 0) return null;
-    return round(($item['usage'] / $item['maximum']) * 100, 1);
-}
-
-$systemStatus = [
-    'cpu'       => ['status' => resourceStatus($cpuData),       'percent' => resourcePercent($cpuData),       'label' => $cpuData['description']       ?? 'CPU'],
-    'memory'    => ['status' => resourceStatus($memoryData),    'percent' => resourcePercent($memoryData),    'label' => $memoryData['description']    ?? 'Memory'],
-    'processes' => ['status' => resourceStatus($processesData), 'percent' => resourcePercent($processesData), 'label' => $processesData['description'] ?? 'Processes'],
-    'database'  => ['status' => $dbConnected ? 'operational' : 'critical', 'percent' => null, 'label' => 'Database'],
-];
-
-// ── Performance metrics from CPanel resource usage ───────────────────────────
-
-$performance = [
-    'cpu'       => ['value' => $cpuData       ? (float)$cpuData['usage']       : null, 'max' => $cpuData       ? (float)$cpuData['maximum']       : null, 'percent' => resourcePercent($cpuData),       'unit' => '%'],
-    'memory'    => ['value' => $memoryData    ? (float)$memoryData['usage']    : null, 'max' => $memoryData    ? (float)$memoryData['maximum']    : null, 'percent' => resourcePercent($memoryData),    'unit' => 'MB'],
-    'processes' => ['value' => $processesData ? (float)$processesData['usage'] : null, 'max' => $processesData ? (float)$processesData['maximum'] : null, 'percent' => resourcePercent($processesData), 'unit' => ''],
-];
-
-echo json_encode([
-    'monitors'      => [
-        'total'   => $totalMonitors,
-        'healthy' => $totalUp,
-        'warning' => $totalWarning,
-        'critical'=> $totalDown,
-    ],
-    'recentActivity' => $recentActivity,
-    'systemStatus'   => $systemStatus,
-    'performance'    => $performance,
-    'generatedAt'    => date('Y-m-d\TH:i:s\Z'),
-], JSON_UNESCAPED_UNICODE);
+echo json_encode(PublicStats::generate(), JSON_UNESCAPED_UNICODE);

--- a/Src/cache/.htaccess
+++ b/Src/cache/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
## 📑 Description
Introduce a new `PublicStats` class to centralize the logic for generating public dashboard statistics and caching the results. This class computes and returns combined monitor statistics, system status, and performance metrics.

A new script, `GeneratePublicStats.php`, periodically pre-computes these stats and writes them to a cache file. This reduces load on the `public-stats.php` endpoint by serving cached data. API will fallback to generating stats if cache is outdated.

Add `.htaccess` to `cache` directory to prevent direct access, while allowing `.htaccess` file itself to be committed for configuration.

Update `.gitignore` to ensure the `.htaccess` file in the `cache` directory is included in the repository while other cache files are ignored.

These changes improve performance and reliability of the public stats API by using a cache mechanism.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Introduce a centralized public stats generator with file-based caching to reduce load on the public stats API and support periodic pre-computation via a CLI worker.

New Features:
- Add a PublicStats library class to aggregate monitor, system status, and performance metrics for the public dashboard.
- Serve public stats from a JSON cache file with a fallback to on-demand generation when the cache is missing or stale.
- Introduce a CLI worker script to periodically generate and persist public stats to the cache file.
- Add an .htaccess file to the cache directory to control access to cached public stats files.

Enhancements:
- Refactor the public-stats API endpoint to delegate stats generation to the new PublicStats service class for reuse and maintainability.