### PR TITLE
feature: add statistics endpoint for webhook processing states

### DIFF
--- a/Src/Library/Webhooks.php
+++ b/Src/Library/Webhooks.php
@@ -105,4 +105,9 @@ class Webhooks
     {
         return $this->doRequest("github/workflow/{$sequence}", "delete", 202);
     }
+
+    public function getStatistics(): mixed
+    {
+        return $this->doRequest("processing-state", "get", 200);
+    }
 }

--- a/Src/api/v1/webhooks-statistics.php
+++ b/Src/api/v1/webhooks-statistics.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once 'session_validator.php';
+require_once '../../vendor/autoload.php';
+
+use GuiBranco\ProjectsMonitor\Library\Webhooks;
+
+$webhooks = new Webhooks();
+$data = $webhooks->getStatistics();
+echo json_encode($data);

--- a/Src/index.php
+++ b/Src/index.php
@@ -395,6 +395,13 @@ $configuration = new Configuration();
          </div>
          <div id="webhooks_statistics" class="section-content"></div>
       </div>
+
+      <div class="full-width-section">
+         <div class="section-header">
+            <i class="bi bi-stack me-2"></i>Processing State Counts <span id="counter_webhook_processing_stats" class="badge rounded-pill"></span>
+         </div>
+         <div id="webhook_processing_stats" class="section-content"></div>
+      </div>
    </div>
 
    <?php include_once __DIR__ . '/footer.php'; ?>

--- a/Src/static/api.js
+++ b/Src/static/api.js
@@ -263,6 +263,7 @@ export class DataLoader {
       `${API_ENDPOINTS.WEBHOOKS}?feedOptionsFilter=${feedState.filter}&workflowsLimiterEnabled=${workflowLimiterState.enabled}&workflowsLimiterQuantity=${workflowLimiterState.limitValue}`,
       (data) => window.showWebhook?.(data)
     );
+    this.apiManager.load(API_ENDPOINTS.WEBHOOKS_STATISTICS, (data) => window.showWebhookProcessingStats?.(data));
   }
 
   /**

--- a/Src/static/constants.js
+++ b/Src/static/constants.js
@@ -35,7 +35,8 @@ export const API_ENDPOINTS = {
   UPTIMEROBOT: "api/v1/uptimerobot",
   WIREGUARD: "api/v1/wireguard",
   POSTMAN: "api/v1/postman",
-  WEBHOOKS: "api/v1/webhooks"
+  WEBHOOKS: "api/v1/webhooks",
+  WEBHOOKS_STATISTICS: "api/v1/webhooks-statistics"
 };
 
 export const CHART_OPTIONS = {

--- a/Src/static/dataDisplay.js
+++ b/Src/static/dataDisplay.js
@@ -602,4 +602,41 @@ export class DataDisplayManager {
   showWireGuard(response) {
     this.chartManager.drawDataTable(response.wireguard, "wireguard", CHART_OPTIONS.table);
   }
+
+  /**
+   * Renders processing state counts from the webhooks /statistics endpoint as a table.
+   * Rows = database tables, columns = processing states (NEW, RE_REQUESTED, UPDATED, PROCESSING, PROCESSED).
+   */
+  showWebhookProcessingStats(response) {
+    const states = ["NEW", "RE_REQUESTED", "UPDATED", "PROCESSING", "PROCESSED"];
+    const tables = [
+      "github_branches",
+      "github_comments",
+      "github_installations",
+      "github_issues",
+      "github_pull_requests",
+      "github_pushes",
+      "github_repositories",
+      "github_signature",
+      "github_users",
+    ];
+
+    const header = ["Table", ...states];
+    const rows = tables.map((table) => {
+      const displayName = table.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+      return [displayName, ...states.map((state) => (response[state]?.[table] ?? 0))];
+    });
+
+    const data = [header, ...rows];
+
+    const counterEl = document.getElementById("counter_webhook_processing_stats");
+    if (counterEl) {
+      const total = rows.reduce((sum, row) => {
+        return sum + states.reduce((s, _, i) => s + (row[i + 1] || 0), 0);
+      }, 0);
+      counterEl.innerHTML = total;
+    }
+
+    this.chartManager.drawChartByType(data, "table", "webhook_processing_stats", CHART_OPTIONS.table);
+  }
 }

--- a/Src/static/main.js
+++ b/Src/static/main.js
@@ -46,6 +46,7 @@ class DashboardApp {
     window.showQueues = this.dataDisplayManager.showQueues.bind(this.dataDisplayManager);
     window.showUpTimeRobot = this.dataDisplayManager.showUpTimeRobot.bind(this.dataDisplayManager);
     window.showWebhook = this.dataDisplayManager.showWebhook.bind(this.dataDisplayManager);
+    window.showWebhookProcessingStats = this.dataDisplayManager.showWebhookProcessingStats.bind(this.dataDisplayManager);
     window.showWireGuard = this.dataDisplayManager.showWireGuard.bind(this.dataDisplayManager);
 
     // Expose API functions
@@ -124,7 +125,8 @@ class DashboardApp {
       webhooks: JSON.parse(
         '{"senders":[],"events":[["Event","Hits"]],"feed":[],"repositories":[],"total":0,"statistics":[["Date","Table #1"],["01/01",0]],"statistics_github":[["Date","Table #1"],["01/01",0]],"branches":[], "pull_requests":[], "workflow_runs":[],"total_workflow_runs":0, "installations":0, "installation_repositories": [], "installation_repositories_count": 0}'
       ),
-      errors_db: { errors: [], total: 0 }
+      errors_db: { errors: [], total: 0 },
+      webhooks_statistics: { NEW: {}, RE_REQUESTED: {}, UPDATED: {}, PROCESSING: {}, PROCESSED: {} }
     };
 
     this.dataDisplayManager.showCPanel(presetData.cpanel);
@@ -133,6 +135,7 @@ class DashboardApp {
     this.dataDisplayManager.showQueues(presetData.queues);
     this.dataDisplayManager.showWebhook(presetData.webhooks);
     this.dataDisplayManager.showDbErrors(presetData.errors_db);
+    this.dataDisplayManager.showWebhookProcessingStats(presetData.webhooks_statistics);
 
     // Reinitialize collapsible sections after preset data is loaded
     setTimeout(() => {


### PR DESCRIPTION
## 📑 Description
Add a new `getStatistics` method in `Webhooks` class to fetch webhook processing statistics. This change includes:

- Creation of `webhooks-statistics.php` to handle API requests and output statistics data.
- Inclusion of a section in `index.php` to display Processing State Counts of webhooks.
- Update JavaScript files (`api.js`, `constants.js`, `dataDisplay.js`, `main.js`) to load and render the new statistics data.

The primary goal is to enhance the dashboard by providing detailed insights into the processing states of webhooks across various database tables. This assists in monitoring and diagnosing the webhook processing pipeline.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add backend and frontend support to display webhook processing state statistics in the dashboard.

New Features:
- Expose a new Webhooks::getStatistics method and API endpoint to retrieve webhook processing state counts from the backend.
- Add a dashboard section and table view to display webhook processing state counts per database table.
- Load and render webhook processing statistics via new JavaScript wiring, including preset data and global display hooks.