### PR TITLE
feat(theme): add dark mode toggle and support

### DIFF
--- a/Src/footer.php
+++ b/Src/footer.php
@@ -3,3 +3,22 @@
         <i class="bi bi-github me-1"></i>guibranco/projects-monitor
     </a>
 </footer>
+
+<script>
+    function toggleTheme() {
+        const next = document.documentElement.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-bs-theme', next);
+        localStorage.setItem('pm-theme', next);
+        syncThemeIcons(next);
+    }
+
+    function syncThemeIcons(theme) {
+        document.querySelectorAll('.theme-toggle-icon').forEach(function (el) {
+            el.className = 'fas theme-toggle-icon ' + (theme === 'dark' ? 'fa-sun' : 'fa-moon');
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        syncThemeIcons(document.documentElement.getAttribute('data-bs-theme') || 'light');
+    });
+</script>

--- a/Src/login.php
+++ b/Src/login.php
@@ -91,6 +91,7 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="static/styles-public.css?<?php echo filemtime("static/styles-public.css"); ?>">
+    <script>(function(){var t=localStorage.getItem('pm-theme')||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-bs-theme',t);})();</script>
 </head>
 
 <body class="bg-light">
@@ -102,9 +103,14 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
                 <i class="fas fa-project-diagram text-primary me-2"></i>
                 <strong>Projects Monitor</strong>
             </span>
-            <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#loginModal">
-                <i class="fas fa-sign-in-alt me-1"></i>Sign In
-            </button>
+            <div class="d-flex align-items-center gap-2">
+                <button class="theme-toggle-btn" onclick="toggleTheme()" aria-label="Toggle theme">
+                    <i class="fas fa-moon theme-toggle-icon"></i>
+                </button>
+                <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#loginModal">
+                    <i class="fas fa-sign-in-alt me-1"></i>Sign In
+                </button>
+            </div>
         </div>
     </nav>
 

--- a/Src/recover.php
+++ b/Src/recover.php
@@ -147,19 +147,34 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="static/styles-public.css?<?php echo filemtime("static/styles-public.css"); ?>">
+    <script>(function(){var t=localStorage.getItem('pm-theme')||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-bs-theme',t);})();</script>
 </head>
 
-<body class="bg-light">
+<body>
+    <nav class="navbar bg-white shadow-sm sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand mb-0" href="login.php">
+                <i class="fas fa-project-diagram text-primary me-2"></i>
+                <strong>Projects Monitor</strong>
+            </a>
+            <button class="theme-toggle-btn" onclick="toggleTheme()" aria-label="Toggle theme">
+                <i class="fas fa-moon theme-toggle-icon"></i>
+            </button>
+        </div>
+    </nav>
+
     <div class="container">
         <div class="row justify-content-center mt-5">
             <div class="col-md-6">
-                <div class="card">
+                <div class="card data-card">
                     <div class="card-body">
-                        <h3 class="card-title text-center">Recover Password</h3>
+                        <h5 class="card-title text-center mb-4">
+                            <i class="fas fa-key text-primary me-2"></i>Recover Password
+                        </h5>
                         <?php if ($message): ?>
                             <div class="alert alert-info"><?php echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8'); ?>
                             </div>
@@ -184,6 +199,8 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
         </div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha256-CDOy6cOibCWEdsRiZuaHf8dSGGJRYuBGC+mjoJimHGw=" crossorigin="anonymous"></script>
     <?php include_once __DIR__ . '/footer.php'; ?>
 </body>
 

--- a/Src/reset.php
+++ b/Src/reset.php
@@ -76,19 +76,34 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha384-5e2ESR8Ycmos6g3gAKr1Jvwye8sW4U1u/cAKulfVJnkakCcMqhOudbtPnvJ+nbv7" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="static/styles-public.css?<?php echo filemtime("static/styles-public.css"); ?>">
+    <script>(function(){var t=localStorage.getItem('pm-theme')||(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-bs-theme',t);})();</script>
 </head>
 
-<body class="bg-light">
+<body>
+    <nav class="navbar bg-white shadow-sm sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand mb-0" href="login.php">
+                <i class="fas fa-project-diagram text-primary me-2"></i>
+                <strong>Projects Monitor</strong>
+            </a>
+            <button class="theme-toggle-btn" onclick="toggleTheme()" aria-label="Toggle theme">
+                <i class="fas fa-moon theme-toggle-icon"></i>
+            </button>
+        </div>
+    </nav>
+
     <div class="container">
         <div class="row justify-content-center mt-5">
             <div class="col-md-6">
-                <div class="card">
+                <div class="card data-card">
                     <div class="card-body">
-                        <h3 class="card-title text-center">Reset Password</h3>
+                        <h5 class="card-title text-center mb-4">
+                            <i class="fas fa-lock text-primary me-2"></i>Reset Password
+                        </h5>
                         <?php if ($message): ?>
                             <div class="alert alert-info"><?php echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8'); ?>
                             </div>
@@ -116,6 +131,8 @@ $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
             </div>
         </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha256-CDOy6cOibCWEdsRiZuaHf8dSGGJRYuBGC+mjoJimHGw=" crossorigin="anonymous"></script>
     <?php include_once __DIR__ . '/footer.php'; ?>
 
     <script>

--- a/Src/static/styles-public.css
+++ b/Src/static/styles-public.css
@@ -281,3 +281,135 @@ footer {
   border-radius: 3px;
   transition: width 0.4s ease;
 }
+
+/* ── Theme toggle button ────────────────────────────────────── */
+.theme-toggle-btn {
+  background: none;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 20px;
+  padding: 0.25rem 0.65rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #6c757d;
+  line-height: 1.5;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.theme-toggle-btn:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+  color: #343a40;
+}
+
+/* ── Dark mode overrides ────────────────────────────────────── */
+
+/* bg-white used on navbars and card headers */
+[data-bs-theme="dark"] .bg-white {
+  background-color: var(--bs-tertiary-bg) !important;
+}
+
+[data-bs-theme="dark"] .navbar {
+  border-bottom: 1px solid var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .data-card {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.35);
+}
+
+[data-bs-theme="dark"] .data-card .card-header {
+  border-bottom-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .stats-card {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.35);
+}
+
+/* Tables */
+[data-bs-theme="dark"] .public-table thead th {
+  background-color: rgba(110, 168, 254, 0.07);
+  color: var(--bs-secondary-color);
+  border-bottom-color: rgba(110, 168, 254, 0.15);
+}
+
+[data-bs-theme="dark"] .public-table tbody td {
+  color: var(--bs-body-color);
+  border-bottom-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .public-table tbody tr:hover td {
+  background-color: rgba(110, 168, 254, 0.05);
+}
+
+/* Activity list */
+[data-bs-theme="dark"] .activity-item {
+  border-bottom-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .activity-item:hover {
+  background-color: rgba(110, 168, 254, 0.05);
+}
+
+[data-bs-theme="dark"] .activity-name {
+  color: var(--bs-body-color);
+}
+
+[data-bs-theme="dark"] .activity-time {
+  color: var(--bs-secondary-color);
+}
+
+[data-bs-theme="dark"] .activity-empty {
+  color: var(--bs-secondary-color);
+}
+
+/* System status */
+[data-bs-theme="dark"] .status-row {
+  border-bottom-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .status-row-label {
+  color: var(--bs-secondary-color);
+}
+
+/* Performance */
+[data-bs-theme="dark"] .perf-label {
+  color: var(--bs-secondary-color);
+}
+
+[data-bs-theme="dark"] .perf-value {
+  color: var(--bs-tertiary-color);
+}
+
+[data-bs-theme="dark"] .perf-bar-track {
+  background-color: var(--bs-secondary-bg);
+}
+
+/* Queue count pill */
+[data-bs-theme="dark"] .queue-count {
+  background-color: var(--bs-secondary-bg);
+  color: var(--bs-secondary-color);
+}
+
+[data-bs-theme="dark"] .queue-count.has-messages {
+  background-color: rgba(255, 193, 7, 0.15);
+  color: #ffc107;
+}
+
+/* Processing state */
+[data-bs-theme="dark"] .state-count {
+  color: var(--bs-tertiary-color);
+}
+
+/* Footer */
+[data-bs-theme="dark"] footer {
+  border-top-color: var(--bs-border-color);
+}
+
+/* Theme toggle button in dark mode */
+[data-bs-theme="dark"] .theme-toggle-btn {
+  border-color: rgba(255, 255, 255, 0.15);
+  color: var(--bs-secondary-color);
+}
+
+[data-bs-theme="dark"] .theme-toggle-btn:hover {
+  background-color: rgba(255, 255, 255, 0.07);
+  color: var(--bs-body-color);
+}


### PR DESCRIPTION
## 📑 Description
Implement a theme toggle feature by introducing a button for switching between light and dark modes. The button utilizes local storage to remember user preferences. Additionally, style adjustments are made to support dark mode, ensuring that the UI elements adapt accordingly with CSS variable-dependent color changes. This enhancement improves user experience by allowing preference customization.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a persistent light/dark theme toggle to the public authentication pages and apply dark mode styling across shared components.

New Features:
- Introduce a theme toggle control on login, password recovery, and reset pages that switches between light and dark modes and persists the choice via local storage.

Enhancements:
- Apply dark mode-specific styling tokens and overrides for shared UI elements such as navbars, cards, tables, activity lists, status rows, performance metrics, queue pills, and footer to ensure consistent appearance across themes.
- Initialize the Bootstrap theme on page load based on stored preference or system color scheme and synchronize toggle button icons with the active theme.
- Add integrity and crossorigin attributes to external Bootstrap, Font Awesome, and Bootstrap Icons assets for improved security.