### PR TITLE
feat: migrate charts to ECharts and tables to Grid.js

### DIFF
--- a/Src/index.php
+++ b/Src/index.php
@@ -5,20 +5,20 @@ require_once 'vendor/autoload.php';
 use GuiBranco\ProjectsMonitor\Library\Configuration;
 
 if (!isset($_SESSION['last_activity']) || time() - $_SESSION['last_activity'] > 1800) {
-   session_unset();
-   session_destroy();
-   header('Location: login.php');
-   header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
-   header('Pragma: no-cache');
-   exit;
+    session_unset();
+    session_destroy();
+    header('Location: login.php');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    exit;
 }
 $_SESSION['last_activity'] = time();
 
 if (!isset($_SESSION['user_id'])) {
-   header('Location: login.php');
-   header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
-   header('Pragma: no-cache');
-   exit;
+    header('Location: login.php');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    exit;
 }
 $username = $_SESSION['username'] ?? '';
 $configuration = new Configuration();

--- a/Src/index.php
+++ b/Src/index.php
@@ -35,6 +35,7 @@ $configuration = new Configuration();
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
       integrity="sha512-dPXYcDub/aeb08c63jRq/k6GaKccl256JQy/AnOq7CAnEZ9FzSL9wSbcZkMp4R26vBsMLFYH4kQ67/bbV8XaCQ=="
       crossorigin="anonymous">
+   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridjs@6.2.0/dist/theme/mermaid.min.css">
    <link rel="preconnect" href="https://fonts.googleapis.com">
    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
@@ -480,7 +481,8 @@ $configuration = new Configuration();
 
    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       integrity="sha256-CDOy6cOibCWEdsRiZuaHf8dSGGJRYuBGC+mjoJimHGw=" crossorigin="anonymous"></script>
-   <script src="https://www.gstatic.com/charts/loader.js"></script>
+   <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js"></script>
+   <script src="https://cdn.jsdelivr.net/npm/gridjs@6.2.0/dist/gridjs.umd.js"></script>
    <script type="module" src="static/main.js?<?php echo filemtime("static/main.js"); ?>"></script>
    <script src="https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js" defer></script>
    <script>

--- a/Src/static/charts.js
+++ b/Src/static/charts.js
@@ -1,7 +1,11 @@
 // charts.js
+import { GridManager } from './gridManager.js';
+
 export class ChartManager {
   constructor() {
-    this.google = window.google;
+    this.echarts = window.echarts;
+    this.gridManager = new GridManager();
+    this._echartsIds = new Set();
   }
 
   /**
@@ -18,7 +22,7 @@ export class ChartManager {
    */
   deepMerge(target, source) {
     const result = { ...target };
-    
+
     for (const key in source) {
       if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
         result[key] = this.deepMerge(result[key] || {}, source[key]);
@@ -26,102 +30,81 @@ export class ChartManager {
         result[key] = source[key];
       }
     }
-    
+
     return result;
   }
 
+  #getOrInitChart(elementId) {
+    const el = document.getElementById(elementId);
+    if (!el) {
+      console.error(`Element with id ${elementId} not found`);
+      return null;
+    }
+    let instance = this.echarts.getInstanceByDom(el);
+    if (!instance) {
+      instance = this.echarts.init(el);
+      this._echartsIds.add(elementId);
+    }
+    return instance;
+  }
+
   /**
-   * Draws a Google Visualization chart of the specified type.
-   *
-   * This function initializes a chart based on the provided data, chart type,
-   * element ID, and custom options. It handles various chart types including table,
-   * line, pie, and gauge. The function also manages hiding a specific column if
-   * requested and adds an event listener to log selections made in the chart.
+   * Converts Google-style {min,max,greenTo,yellowTo,redTo} zone thresholds
+   * into ECharts axisLine.lineStyle.color stop-array format.
+   */
+  #zonesToColorStops(options) {
+    const min = options.min ?? 0;
+    const max = options.max ?? 100;
+    const range = (max - min) || 1;
+    const frac = (v) => Math.min(1, Math.max(0, (v - min) / range));
+    return [
+      [frac(options.greenTo ?? max), '#2ecc71'],
+      [frac(options.yellowTo ?? max), '#f1c40f'],
+      [frac(options.redTo ?? max), '#e74c3c'],
+    ];
+  }
+
+  #baseText() {
+    return {
+      backgroundColor: 'transparent',
+      textStyle: { color: '#ffffff' },
+      title: { textStyle: { color: '#ffffff' } },
+    };
+  }
+
+  #legendOff(options) {
+    return options.legend === 'none' || options.legend?.position === 'none';
+  }
+
+  /**
+   * Draws a chart of the specified type (table, line, pie, gauge) into elementId.
    *
    * @param {Array<Array<any>>} data - The dataset for the chart.
    * @param {string} chartType - The type of chart to draw (e.g., 'table', 'line', 'pie', 'gauge').
    * @param {string} elementId - The ID of the HTML element where the chart will be rendered.
    * @param {Object} customOptions - Custom options for the chart.
-   * @param {number} [hideColumn=-1] - Index of the column to hide in the chart (default is -1, indicating no column hidden).
-   * @returns {Object|null} An object containing chart details or null if an error occurs.
+   * @param {number} [hideColumn=-1] - Index of the column to hide (table charts only).
+   * @returns {Object|null} The underlying chart/grid instance, or null on error.
    */
   drawChartByType(data, chartType, elementId, customOptions, hideColumn = -1) {
-    if (!this.google.visualization) {
-      console.error("Google Visualization API not loaded");
-      return null;
-    }
-
     if (!data || !elementId || !customOptions) {
       console.error("Invalid parameters passed to drawChartByType");
       return null;
     }
 
-    const element = document.getElementById(elementId);
-    if (!element) {
-      console.error(`Element with id ${elementId} not found`);
-      return null;
-    }
-
-    const result = {
-      chartType,
-      elementId,
-    };
-
     switch (chartType) {
       case "table":
-        result.chart = new this.google.visualization.Table(element);
-        break;
+        return this.gridManager.draw(data, elementId, customOptions, hideColumn);
       case "line":
-        result.chart = new this.google.visualization.LineChart(element);
-        break;
+        return this.#drawLine(data, elementId, customOptions);
       case "pie":
-        result.chart = new this.google.visualization.PieChart(element);
-        break;
+        return this.#drawPie(data, elementId, customOptions);
       case "gauge":
-        result.chart = new this.google.visualization.Gauge(element);
-        break;
+        return this.#drawGauge(data, elementId, customOptions);
       default:
         console.error(`Invalid chart type: ${chartType}`);
         return null;
     }
-
-    result.dataTable = this.google.visualization.arrayToDataTable(data);
-
-    const defaultOptions = {
-      backgroundColor: 'transparent',
-      titleTextStyle: { color: '#ffffff' },
-      hAxis: { textStyle: { color: '#ffffff' } },
-      vAxis: { textStyle: { color: '#ffffff' } },
-      legend: { textStyle: { color: '#ffffff' } }
-    };
-
-    const options = this.deepMerge(defaultOptions, customOptions);
-
-    if (hideColumn >= 0 && data.length > 0) {
-      result.view = new this.google.visualization.DataView(result.dataTable);
-      if (data[0].length > hideColumn) {
-        result.view.hideColumns([hideColumn]);
-      }
-
-      result.chart.draw(result.view, options);
-
-      this.google.visualization.events.addListener(result.chart, "select", () => {
-        const selection = result.chart.getSelection();
-        if (selection.length > 0) {
-          const { row } = selection[0];
-          const item = result.dataTable.getValue(row, 0);
-          const hiddenInfo = result.dataTable.getValue(
-            row,
-            data[0].length > hideColumn ? hideColumn : 0
-          );
-          console.log(`You clicked on ${item}\nHidden Info: ${hiddenInfo}`);
-        }
-      });
-    } else {
-      result.chart.draw(result.dataTable, options);
-    }
-
-    return result;
   }
 
   /**
@@ -164,5 +147,133 @@ export class ChartManager {
       elementId,
       options
     );
+  }
+
+  /**
+   * Resizes every ECharts instance this manager has ever initialized. Used
+   * to fix charts drawn while their container was hidden (e.g. inside a
+   * collapsed section), since ECharts measures pixel dimensions at draw time.
+   */
+  resizeAll() {
+    for (const id of this._echartsIds) {
+      const el = document.getElementById(id);
+      if (el) {
+        this.echarts.getInstanceByDom(el)?.resize();
+      }
+    }
+  }
+
+  #drawGauge(data, elementId, options) {
+    const chart = this.#getOrInitChart(elementId);
+    if (!chart) return null;
+
+    const [, [label, value]] = data;
+    const option = this.deepMerge(this.#baseText(), {
+      series: [{
+        type: 'gauge',
+        min: options.min ?? 0,
+        max: options.max ?? 100,
+        startAngle: 200,
+        endAngle: -20,
+        progress: { show: false },
+        axisLine: { lineStyle: { width: 14, color: this.#zonesToColorStops(options) } },
+        axisTick: { show: false },
+        splitLine: { length: 10, lineStyle: { color: '#ffffff', width: 2 } },
+        axisLabel: { color: '#ffffff', fontSize: 10, distance: 18 },
+        pointer: { itemStyle: { color: '#ffffff' } },
+        title: { fontSize: 13, offsetCenter: [0, '70%'] },
+        detail: { fontSize: 18, offsetCenter: [0, '40%'], color: '#ffffff', formatter: '{value}' },
+        data: [{ value, name: label }],
+      }],
+    });
+
+    chart.setOption(option, true);
+    chart.resize();
+    return chart;
+  }
+
+  #drawLine(data, elementId, options) {
+    const chart = this.#getOrInitChart(elementId);
+    if (!chart) return null;
+
+    const [header, ...rows] = data;
+    const categories = rows.map((r) => r[0]);
+    const seriesNames = header.slice(1);
+    const legendOff = this.#legendOff(options);
+    const legendRight = options.legend?.position === 'right';
+
+    const series = seriesNames.map((name, i) => ({
+      name,
+      type: 'line',
+      symbolSize: options.pointSize ?? 4,
+      data: rows.map((r) => r[i + 1]),
+      ...(options.series?.[i]?.color ? {
+        itemStyle: { color: options.series[i].color },
+        lineStyle: { color: options.series[i].color },
+      } : {}),
+    }));
+
+    const option = this.deepMerge(this.#baseText(), {
+      title: options.title ? { text: options.title, textStyle: { fontSize: 14 } } : undefined,
+      tooltip: { trigger: 'axis' },
+      legend: legendOff
+        ? { show: false }
+        : { show: true, textStyle: { color: '#fff' }, ...(legendRight ? { orient: 'vertical', right: 0, top: 'middle' } : {}) },
+      grid: { left: 45, right: legendRight ? 110 : 20, bottom: 55, top: options.title ? 45 : 25, containLabel: true },
+      xAxis: {
+        type: 'category',
+        data: categories,
+        name: options.hAxis?.title,
+        nameLocation: 'middle',
+        nameGap: 30,
+        axisLabel: { color: '#fff', fontSize: options.hAxis?.textStyle?.fontSize ?? 11, rotate: 30 },
+        axisLine: { lineStyle: { color: '#fff' } },
+      },
+      yAxis: {
+        type: 'value',
+        axisLabel: { color: '#fff' },
+        splitLine: { lineStyle: { color: 'rgba(255,255,255,.15)' } },
+      },
+      series,
+    });
+
+    chart.setOption(option, true);
+    chart.resize();
+    return chart;
+  }
+
+  #drawPie(data, elementId, options) {
+    const chart = this.#getOrInitChart(elementId);
+    if (!chart) return null;
+
+    const [, ...rows] = data;
+    const seriesData = rows.map((r) => ({ name: r[0], value: r[1] }));
+    const legendOff = this.#legendOff(options);
+    const legendRight = options.legend?.position === 'right';
+
+    const option = this.deepMerge(this.#baseText(), {
+      title: options.title ? { text: options.title, left: 'center', textStyle: { fontSize: 14 } } : undefined,
+      tooltip: { trigger: 'item' },
+      legend: legendOff
+        ? { show: false }
+        : {
+          show: true,
+          textStyle: { color: '#fff' },
+          orient: legendRight ? 'vertical' : 'horizontal',
+          ...(legendRight ? { right: 0, top: 'middle' } : { bottom: 0 }),
+        },
+      series: [{
+        type: 'pie',
+        radius: legendRight ? ['0%', '65%'] : ['0%', '70%'],
+        center: legendRight ? ['40%', '50%'] : ['50%', '50%'],
+        data: seriesData,
+        label: { color: '#fff' },
+        labelLine: { lineStyle: { color: '#fff' } },
+      }],
+    });
+
+    chart.setOption(option, true);
+    chart.resize();
+    return chart;
   }
 }

--- a/Src/static/constants.js
+++ b/Src/static/constants.js
@@ -45,17 +45,15 @@ export const API_ENDPOINTS = {
 
 export const CHART_OPTIONS = {
   table: {
-    legend: { position: "none" },
     allowHtml: true,
     showRowNumber: true,
+    sort: false,
+    pagination: false,
+    search: false,
     width: "100%",
     height: "100%",
-    background: {
-      fill: '#000000',
-      opacity: .05,
-    }
   },
-  
+
   gauge: {
     width: "100%",
     height: "100%",

--- a/Src/static/dataDisplay.js
+++ b/Src/static/dataDisplay.js
@@ -407,54 +407,37 @@ export class DataDisplayManager {
     if (!container) return;
 
     const total = response.total ?? 0;
-    if (counterEl) counterEl.textContent = total;
 
     if (!response.errors || response.errors.length === 0) {
       if (truncateBtn) truncateBtn.style.display = "none";
-      container.innerHTML = '<p class="text-muted text-center py-3 mb-0">No error records in the database.</p>';
+      this.chartManager.drawDataTable([[]], "db_error_messages", CHART_OPTIONS.table);
+      if (counterEl) counterEl.textContent = total;
       return;
     }
 
     if (truncateBtn) truncateBtn.style.display = "";
 
+    const header = ["Date", "Log File", "Error", "Location", "Actions"];
     const rows = response.errors.map(err => {
       const basePath       = (err.error_log_path ?? '').split('/').pop();
       const truncatedError = (err.error ?? '').length > 120
         ? err.error.substring(0, 120) + '…'
         : (err.error ?? '');
       const safePath = encodeURIComponent(err.error_log_path ?? '');
-      return `<tr>
-        <td class="text-nowrap small">${this.#escHtml(err.date)}</td>
-        <td class="small font-monospace" title="${this.#escHtml(err.error_log_path)}">${this.#escHtml(basePath)}</td>
-        <td class="small" title="${this.#escHtml(err.error)}">${this.#escHtml(truncatedError)}</td>
-        <td class="small font-monospace text-nowrap">${this.#escHtml(err.file)}:${err.line}</td>
-        <td class="text-center">
-          <button class="btn btn-danger btn-sm"
+      const btn = `<button class="btn btn-danger btn-sm"
                   data-action="delete-path"
                   data-path="${safePath}"
                   title="Delete all errors for this log file"
                   aria-label="Delete all errors for ${this.#escHtml(basePath)}">
             <i class="bi bi-trash2"></i>
-          </button>
-        </td>
-      </tr>`;
-    }).join('');
+          </button>`;
+      const logFile = `<span title="${this.#escHtml(err.error_log_path)}">${this.#escHtml(basePath)}</span>`;
+      const errorCell = `<span title="${this.#escHtml(err.error)}">${this.#escHtml(truncatedError)}</span>`;
+      return [this.#escHtml(err.date), logFile, errorCell, this.#escHtml(`${err.file}:${err.line}`), btn];
+    });
 
-    container.innerHTML = `
-      <div class="table-responsive">
-        <table class="table table-sm table-hover align-middle mb-0 db-errors-table">
-          <thead>
-            <tr>
-              <th>Date</th>
-              <th>Log File</th>
-              <th>Error</th>
-              <th>Location</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>${rows}</tbody>
-        </table>
-      </div>`;
+    this.chartManager.drawDataTable([header, ...rows], "db_error_messages", CHART_OPTIONS.table);
+    if (counterEl) counterEl.textContent = total;
 
     if (!this.eventAssignedDbErrors) {
       this.eventAssignedDbErrors = true;
@@ -645,9 +628,9 @@ export class DataDisplayManager {
     if (!container) return;
 
     const items = Array.isArray(response) ? response : [];
-    if (counterEl) counterEl.textContent = items.length;
 
     if (items.length === 0) {
+      if (counterEl) counterEl.textContent = 0;
       container.innerHTML = '<p class="text-muted text-center py-3 mb-0">No pull requests pending processing.</p>';
       return;
     }
@@ -662,50 +645,26 @@ export class DataDisplayManager {
       }
     };
 
+    const header = ["#Seq", "Repository", "PR", "Sender", "Branch", "State",
+      "Processing Date", "Receiver", "Handler", "Bot"];
+
     const rows = items.map(item => {
       const repo = `${this.#escHtml(item.repositoryOwner)}/${this.#escHtml(item.repositoryName)}`;
       const prLink = `<a href="https://github.com/${this.#escHtml(item.repositoryOwner)}/${this.#escHtml(item.repositoryName)}/pull/${item.number}" target="_blank" rel="noopener noreferrer">#${item.number}</a>`;
       const stateBadge = `<span class="badge ${stateBadgeClass(item.processingState)}">${this.#escHtml(item.processingState)}</span>`;
       const ref = item.ref ? this.#escHtml(item.ref.replace('refs/heads/', '')) : '—';
+      const refCell = `<span title="${this.#escHtml(item.ref ?? '')}">${ref}</span>`;
       const sender = item.senderLogin ? this.#escHtml(item.senderLogin) : (item.sender ? this.#escHtml(item.sender) : '—');
       const processingDate = item.processingDate ? this.#escHtml(item.processingDate) : '—';
       const receiverVer = item.webhooksReceiverVersion ? this.#escHtml(item.webhooksReceiverVersion) : '—';
       const handlerVer = item.webhooksHandlerVersion ? this.#escHtml(item.webhooksHandlerVersion) : '—';
       const botVer = item.gstracciniBotVersion ? this.#escHtml(item.gstracciniBotVersion) : '—';
-      return `<tr>
-        <td class="text-nowrap small text-muted">${item.sequence}</td>
-        <td class="small font-monospace">${repo}</td>
-        <td class="small">${prLink}</td>
-        <td class="small">${sender}</td>
-        <td class="small font-monospace text-truncate" style="max-width:140px" title="${this.#escHtml(item.ref ?? '')}">${ref}</td>
-        <td class="text-nowrap">${stateBadge}</td>
-        <td class="small text-nowrap">${processingDate}</td>
-        <td class="small text-center">${receiverVer}</td>
-        <td class="small text-center">${handlerVer}</td>
-        <td class="small text-center">${botVer}</td>
-      </tr>`;
-    }).join('');
+      return [item.sequence, repo, prLink, sender, refCell, stateBadge,
+        processingDate, receiverVer, handlerVer, botVer];
+    });
 
-    container.innerHTML = `
-      <div class="table-responsive">
-        <table class="table table-sm table-hover align-middle mb-0">
-          <thead>
-            <tr>
-              <th class="text-muted">#Seq</th>
-              <th>Repository</th>
-              <th>PR</th>
-              <th>Sender</th>
-              <th>Branch</th>
-              <th>State</th>
-              <th>Processing Date</th>
-              <th class="text-center">Receiver</th>
-              <th class="text-center">Handler</th>
-              <th class="text-center">Bot</th>
-            </tr>
-          </thead>
-          <tbody>${rows}</tbody>
-        </table>
-      </div>`;
+    this.chartManager.drawDataTable([header, ...rows], "pr_processing", CHART_OPTIONS.table);
+    if (counterEl) counterEl.textContent = items.length;
   }
 
   /**

--- a/Src/static/gridManager.js
+++ b/Src/static/gridManager.js
@@ -1,0 +1,66 @@
+// gridManager.js
+export class GridManager {
+  constructor() {
+    this.gridjs = window.gridjs;
+  }
+
+  /**
+   * Renders (or fully re-renders) a Grid.js table into elementId from a
+   * Google-style [header, ...rows] array. Mirrors the previous
+   * google.visualization.Table semantics: allowHtml, showRowNumber,
+   * hideColumn, and the "[[]]" empty sentinel are all preserved.
+   */
+  draw(data, elementId, options = {}, hideColumn = -1) {
+    const el = document.getElementById(elementId);
+    if (!el) {
+      console.error(`Element with id ${elementId} not found`);
+      return null;
+    }
+
+    const headerRow = Array.isArray(data) && data.length > 0 ? data[0] : [];
+    const bodyRows = Array.isArray(data) && data.length > 1 ? data.slice(1) : [];
+
+    // Always fully recreate, matching the old "new google.visualization.Table()
+    // fresh on every redraw" semantics, instead of diffing/updateConfig.
+    el.innerHTML = '';
+
+    if (!headerRow || headerRow.length === 0) {
+      // "[[]]" empty-state sentinel: render nothing, matching the old
+      // arrayToDataTable([[]]) behavior of an effectively blank table.
+      return null;
+    }
+
+    const showRowNumber = options.showRowNumber !== false;
+    const allowHtml = options.allowHtml === true;
+
+    let columns = headerRow.map((h, i) => ({
+      name: String(h ?? ''),
+      hidden: i === hideColumn,
+    }));
+    if (showRowNumber) {
+      columns = [{ name: '#' }, ...columns];
+    }
+
+    const wrapCell = (cell) => (allowHtml && typeof cell === 'string'
+      ? this.gridjs.html(cell)
+      : cell);
+
+    const gridData = bodyRows.map((row, i) => {
+      const cells = showRowNumber ? [i + 1, ...row] : [...row];
+      return cells.map(wrapCell);
+    });
+
+    const grid = new this.gridjs.Grid({
+      columns,
+      data: gridData,
+      sort: false,
+      pagination: false,
+      search: false,
+      resizable: false,
+      className: { table: 'gridjs-table-dark' },
+    });
+
+    grid.render(el);
+    return grid;
+  }
+}

--- a/Src/static/main.js
+++ b/Src/static/main.js
@@ -95,15 +95,113 @@ class DashboardApp {
     const _apiMgr  = this.apiManager;
     const _dispMgr = this.dataDisplayManager;
     let   _msgDetailGroup = null;
+    let   _msgDetailGrid = null;
+    let   _msgDetailMsgs = [];
+    const _expandedMsgIds = new Set();
 
     const _esc = (s) =>
       String(s ?? '')
         .replace(/&/g, '&amp;').replace(/</g, '&lt;')
         .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
+    const MSG_DETAIL_COLUMNS = ['#ID', 'Class', 'Function', 'File : Line',
+      'Type', 'Correlation ID', 'Created At', 'Actions'];
+
+    // Detail (expanded) rows are represented by giving every cell the same
+    // marker object; column 0's formatter renders the real content spanning
+    // the full row width (via a colSpan attribute), the rest render empty
+    // and are hidden — Grid.js has no native "extra sibling row" concept.
+    const _detailMarker = (html) => ({ __detail: true, html });
+
+    const _msgDetailRow = (m) => [
+      m.id,
+      _esc(m.class),
+      _esc(m.function),
+      `${_esc(m.file)}<span class="text-muted">:${_esc(m.line)}</span>`,
+      _esc(m.type),
+      _esc(m.correlation_id),
+      _esc(m.created_at),
+      `<button class="btn btn-sm btn-outline-secondary py-0 me-1"
+         data-action="toggle-msg-detail" data-id="${m.id}"
+         title="View object / args / details">
+         <i class="bi bi-chevron-${_expandedMsgIds.has(m.id) ? 'up' : 'down'}"></i>
+       </button>
+       <button class="btn btn-sm btn-danger py-0"
+         data-action="delete-single-msg" data-id="${m.id}"
+         title="Delete this message">
+         <i class="bi bi-trash"></i>
+       </button>`,
+    ];
+
+    const _msgDetailExtraRow = (m) => {
+      const html = `<dl class="row mb-0 small">
+          <dt class="col-sm-2 text-warning">Object</dt>
+          <dd class="col-sm-10"><code class="text-break">${_esc(m.object)}</code></dd>
+          <dt class="col-sm-2 text-warning">Args</dt>
+          <dd class="col-sm-10"><code class="text-break">${_esc(m.args)}</code></dd>
+          <dt class="col-sm-2 text-warning">Details</dt>
+          <dd class="col-sm-10"><code class="text-break">${_esc(m.details)}</code></dd>
+        </dl>`;
+      const marker = _detailMarker(html);
+      return MSG_DETAIL_COLUMNS.map(() => marker);
+    };
+
+    const _buildMsgDetailGridData = () => {
+      const data = [];
+      for (const m of _msgDetailMsgs) {
+        data.push(_msgDetailRow(m));
+        if (_expandedMsgIds.has(m.id)) {
+          data.push(_msgDetailExtraRow(m));
+        }
+      }
+      return data;
+    };
+
+    const _renderMsgDetailGrid = () => {
+      const body = document.getElementById('msgDetailBody');
+      if (!body) return;
+
+      const columns = MSG_DETAIL_COLUMNS.map((name, colIndex) => ({
+        name,
+        formatter: (cell) => {
+          if (cell && typeof cell === 'object' && cell.__detail) {
+            return colIndex === 0 ? gridjs.html(cell.html) : '';
+          }
+          return typeof cell === 'string' ? gridjs.html(cell) : cell;
+        },
+        attributes: (cell) => {
+          if (cell && typeof cell === 'object' && cell.__detail) {
+            return colIndex === 0
+              ? { colSpan: MSG_DETAIL_COLUMNS.length, class: 'msg-detail-row' }
+              : { style: 'display:none' };
+          }
+          return {};
+        },
+      }));
+
+      if (_msgDetailGrid) {
+        _msgDetailGrid.updateConfig({ columns, data: _buildMsgDetailGridData() }).forceRender();
+        return;
+      }
+
+      body.innerHTML = '';
+      _msgDetailGrid = new gridjs.Grid({
+        columns,
+        data: _buildMsgDetailGridData(),
+        sort: false,
+        pagination: false,
+        search: false,
+        resizable: false,
+        className: { table: 'gridjs-table-dark' },
+      });
+      _msgDetailGrid.render(body);
+    };
+
     const _loadMsgDetails = async (sampleId) => {
       const body = document.getElementById('msgDetailBody');
       if (!body) return;
+      _msgDetailGrid = null;
+      _expandedMsgIds.clear();
       body.innerHTML = `<div class="text-center py-4">
         <div class="spinner-border text-light" role="status">
           <span class="visually-hidden">Loading…</span>
@@ -111,62 +209,14 @@ class DashboardApp {
 
       try {
         const data = await _apiMgr.getMessageDetails(sampleId);
-        const msgs = data.messages ?? [];
+        _msgDetailMsgs = data.messages ?? [];
 
-        if (msgs.length === 0) {
+        if (_msgDetailMsgs.length === 0) {
           body.innerHTML = '<p class="text-center text-muted py-3">No messages found in this group.</p>';
           return;
         }
 
-        const rows = msgs.map(m => `
-          <tr>
-            <td class="text-nowrap">${m.id}</td>
-            <td class="text-nowrap">${_esc(m.class)}</td>
-            <td class="text-nowrap">${_esc(m.function)}</td>
-            <td class="text-nowrap">${_esc(m.file)}<span class="text-muted">:${_esc(m.line)}</span></td>
-            <td class="text-nowrap">${_esc(m.type)}</td>
-            <td class="text-nowrap">${_esc(m.correlation_id)}</td>
-            <td class="text-nowrap">${_esc(m.created_at)}</td>
-            <td class="text-nowrap">
-              <button class="btn btn-sm btn-outline-secondary py-0 me-1"
-                data-bs-toggle="collapse"
-                data-bs-target="#msg-extra-${m.id}"
-                title="View object / args / details">
-                <i class="bi bi-chevron-down"></i>
-              </button>
-              <button class="btn btn-sm btn-danger py-0"
-                data-action="delete-single-msg"
-                data-id="${m.id}"
-                title="Delete this message">
-                <i class="bi bi-trash"></i>
-              </button>
-            </td>
-          </tr>
-          <tr id="msg-extra-${m.id}" class="collapse">
-            <td colspan="8" class="p-3" style="background:rgba(0,0,0,.35);">
-              <dl class="row mb-0 small">
-                <dt class="col-sm-2 text-warning">Object</dt>
-                <dd class="col-sm-10"><code class="text-break">${_esc(m.object)}</code></dd>
-                <dt class="col-sm-2 text-warning">Args</dt>
-                <dd class="col-sm-10"><code class="text-break">${_esc(m.args)}</code></dd>
-                <dt class="col-sm-2 text-warning">Details</dt>
-                <dd class="col-sm-10"><code class="text-break">${_esc(m.details)}</code></dd>
-              </dl>
-            </td>
-          </tr>`).join('');
-
-        body.innerHTML = `
-          <div class="table-responsive">
-            <table class="table table-dark table-sm table-hover align-middle mb-0">
-              <thead class="table-secondary">
-                <tr>
-                  <th>#ID</th><th>Class</th><th>Function</th><th>File : Line</th>
-                  <th>Type</th><th>Correlation ID</th><th>Created At</th><th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>${rows}</tbody>
-            </table>
-          </div>`;
+        _renderMsgDetailGrid();
       } catch (_) {
         body.innerHTML = '<div class="alert alert-danger m-3">Failed to load message details.</div>';
       }
@@ -175,13 +225,26 @@ class DashboardApp {
     // Delegated click handler on the modal body (set up once; body element persists)
     document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('msgDetailBody')?.addEventListener('click', async (e) => {
-        const btn = e.target.closest('[data-action="delete-single-msg"]');
-        if (!btn) return;
-        const id = parseInt(btn.dataset.id, 10);
-        if (!confirm(`Delete message #${id}?`)) return;
-        await _apiMgr.deleteMessageById(id);
-        if (_msgDetailGroup) {
-          _loadMsgDetails(_msgDetailGroup.sampleId);
+        const toggleBtn = e.target.closest('[data-action="toggle-msg-detail"]');
+        if (toggleBtn) {
+          const id = parseInt(toggleBtn.dataset.id, 10);
+          if (_expandedMsgIds.has(id)) {
+            _expandedMsgIds.delete(id);
+          } else {
+            _expandedMsgIds.add(id);
+          }
+          _renderMsgDetailGrid();
+          return;
+        }
+
+        const deleteBtn = e.target.closest('[data-action="delete-single-msg"]');
+        if (deleteBtn) {
+          const id = parseInt(deleteBtn.dataset.id, 10);
+          if (!confirm(`Delete message #${id}?`)) return;
+          await _apiMgr.deleteMessageById(id);
+          if (_msgDetailGroup) {
+            _loadMsgDetails(_msgDetailGroup.sampleId);
+          }
         }
       });
 
@@ -307,9 +370,13 @@ class DashboardApp {
     document.addEventListener('sectionToggled', (e) => {
       const { sectionId, collapsed } = e.detail;
       console.log(`Dashboard: Section ${sectionId} ${collapsed ? 'collapsed' : 'expanded'}`);
-      
-      // You can add custom logic here when sections are toggled
-      // For example, pause/resume chart updates, save analytics, etc.
+
+      // ECharts measures its container's pixel size at draw time, so a chart
+      // drawn while its section was collapsed (max-height: 0) renders 0x0.
+      // Resize every known chart instance whenever a section expands.
+      if (!collapsed) {
+        this.dataDisplayManager.chartManager.resizeAll();
+      }
     });
 
     // Add keyboard shortcuts
@@ -362,14 +429,13 @@ class DashboardApp {
 // Initialize the application
 const app = new DashboardApp();
 
-// Set up Google Charts
-if (typeof google !== 'undefined') {
-  google.charts.load("current", { packages: ["corechart", "table", "gauge"] });
-  google.charts.setOnLoadCallback(() => app.drawChart());
-}
-
-// Set up window load event
-window.addEventListener("load", () => app.init());
+// ECharts and Grid.js are loaded via plain synchronous <script> tags in
+// index.php, before this module executes, so window.echarts/window.gridjs
+// are already defined by the time DashboardApp's constructor runs.
+window.addEventListener("load", () => {
+  app.init();
+  app.drawChart();
+});
 
 // Export the app instance for debugging
 window.dashboardApp = app;

--- a/Src/static/styles.css
+++ b/Src/static/styles.css
@@ -302,8 +302,59 @@ code {
   min-height: 300px;
 }
 
-.google-visualization-table {
-  color: #000;
+/* ===========================================
+   GRID.JS DARK THEME OVERRIDES
+   (mermaid.min.css is Grid.js's only official theme and is light-mode by
+   default, so every surface needs a dark override here to match the rest
+   of the dashboard's glass/dark aesthetic.)
+   =========================================== */
+.gridjs-wrapper {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.gridjs-table {
+  color: #ffffff;
+  background: rgba(0, 0, 0, .05);
+  width: 100%;
+}
+
+.gridjs-th {
+  background: rgba(255, 255, 255, .08);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, .15);
+}
+
+.gridjs-td {
+  background: transparent;
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, .08);
+}
+
+.gridjs-tr:hover .gridjs-td {
+  background: rgba(255, 255, 255, .06);
+}
+
+.gridjs-footer {
+  background: transparent;
+  border: none;
+}
+
+.gridjs-pagination .gridjs-pages button {
+  background: rgba(255, 255, 255, .08);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, .15);
+}
+
+.gridjs-search-input {
+  background: rgba(0, 0, 0, .2);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, .15);
+}
+
+.msg-detail-row {
+  background: rgba(0, 0, 0, .35) !important;
 }
 
 /* ===========================================


### PR DESCRIPTION
## 📑 Description
Replace Google Charts with ECharts for enhanced interactivity and performance, and switch table rendering to Grid.js for a modern UI.

- Replace Google Charts with ECharts across charts.js, updating all relevant helper functions and rendering logic.
- Introduce GridManager integrated with Grid.js to handle table rendering, ensuring consistent behavior with previous implementations.
- Update `index.php` to include ECharts and Grid.js library links, removing the Google Charts loader code.
- Refactor main.js to clean up chart and grid initialization, eliminating Google Charts dependencies.
- Modify styles.css to include dark theme overrides for Grid.js, enhancing overall dashboard aesthetics to match the existing design.
- Update constants and data handling in various components to ensure compatibility with the new chart and grid implementations.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Migrate dashboard visualizations from Google Charts/Tables to ECharts and Grid.js with dark-themed styling and maintain existing behavior.

New Features:
- Introduce an ECharts-based ChartManager supporting line, pie, and gauge charts with dark-mode defaults.
- Add a GridManager abstraction to render data tables using Grid.js while preserving existing table semantics.
- Implement a Grid.js-powered message details grid with expandable detail rows in the dashboard modal.

Enhancements:
- Refactor data display logic to render database error and pull request processing tables via the new Grid.js-backed chart manager.
- Ensure charts resize correctly when sections are expanded by tracking initialized ECharts instances.
- Apply dark-theme overrides for Grid.js tables to match the dashboard’s existing aesthetic.

Build:
- Load ECharts and Grid.js via CDN in index.php and remove the Google Charts loader script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Charts and tables now use a more modern, interactive display with a consistent dark theme.
  * Message details in the modal can now be expanded and collapsed more smoothly.
  * Database errors and pull request processing lists now render in a cleaner tabular view.

* **Bug Fixes**
  * Fixed charts appearing incorrectly after collapsing and reopening sections.
  * Improved chart and table rendering when content is loaded dynamically or shown in hidden areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->