### PR TITLE
feat: enhance confirmation UI with jquery-confirm integration

### DIFF
--- a/Src/index.php
+++ b/Src/index.php
@@ -36,6 +36,7 @@ $configuration = new Configuration();
       integrity="sha512-dPXYcDub/aeb08c63jRq/k6GaKccl256JQy/AnOq7CAnEZ9FzSL9wSbcZkMp4R26vBsMLFYH4kQ67/bbV8XaCQ=="
       crossorigin="anonymous">
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridjs@6.2.0/dist/theme/mermaid.min.css">
+   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery-confirm@3.3.4/css/jquery-confirm.min.css">
    <link rel="preconnect" href="https://fonts.googleapis.com">
    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
@@ -203,7 +204,7 @@ $configuration = new Configuration();
          <div class="chart-container">
             <div class="text-end mb-1">
                <button id="btn_truncate_messages" class="btn btn-warning btn-sm" style="display:none"
-                  onclick="if(window.confirmTruncateMessages?.()) window.truncateMessages?.()">Truncate All
+                  onclick="window.confirmTruncateMessages?.(() => window.truncateMessages?.())">Truncate All
                   Messages</button>
             </div>
             <div id="messages_by_applications"></div>
@@ -234,7 +235,7 @@ $configuration = new Configuration();
          <div class="section-content">
             <div class="text-end mb-1">
                <button id="btn_truncate_db_errors" class="btn btn-warning btn-sm" style="display:none"
-                  onclick="if(window.confirmTruncateDbErrors?.()) window.truncateDbErrors?.()">
+                  onclick="window.confirmTruncateDbErrors?.(() => window.truncateDbErrors?.())">
                   <i class="bi bi-trash me-1"></i>Truncate All
                </button>
             </div>
@@ -483,6 +484,8 @@ $configuration = new Configuration();
       integrity="sha256-CDOy6cOibCWEdsRiZuaHf8dSGGJRYuBGC+mjoJimHGw=" crossorigin="anonymous"></script>
    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js"></script>
    <script src="https://cdn.jsdelivr.net/npm/gridjs@6.2.0/dist/gridjs.umd.js"></script>
+   <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+   <script src="https://cdn.jsdelivr.net/npm/jquery-confirm@3.3.4/js/jquery-confirm.min.js"></script>
    <script type="module" src="static/main.js?<?php echo filemtime("static/main.js"); ?>"></script>
    <script src="https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js" defer></script>
    <script>

--- a/Src/static/dataDisplay.js
+++ b/Src/static/dataDisplay.js
@@ -141,9 +141,7 @@ export class DataDisplayManager {
             const deleteButton = e.target.closest('[data-action="delete"]');
             if (deleteButton) {
               const { directory } = deleteButton.dataset;
-              if (window.confirmDeleteError && window.confirmDeleteError(directory)) {
-                window.deleteErrorLogFile?.(directory);
-              }
+              window.confirmDeleteError?.(directory, () => window.deleteErrorLogFile?.(directory));
             }
           });
       }
@@ -388,9 +386,7 @@ export class DataDisplayManager {
             const deleteButton = e.target.closest('[data-action="delete"]');
             if (deleteButton) {
               const { application } = deleteButton.dataset;
-              if (window.confirmDelete && window.confirmDelete(application)) {
-                window.deleteMessageByApplication?.(application);
-              }
+              window.confirmDelete?.(application, () => window.deleteMessageByApplication?.(application));
             }
           });
       }
@@ -445,9 +441,7 @@ export class DataDisplayManager {
         const btn = e.target.closest('[data-action="delete-path"]');
         if (!btn) return;
         const decoded = decodeURIComponent(btn.dataset.path ?? '');
-        if (window.confirmDeleteErrorsByPath?.(decoded)) {
-          window.deleteErrorsByPath?.(decoded);
-        }
+        window.confirmDeleteErrorsByPath?.(decoded, () => window.deleteErrorsByPath?.(decoded));
       });
     }
   }
@@ -491,9 +485,7 @@ export class DataDisplayManager {
           if (purgeButton) {
             const { host, vhost, queue } = purgeButton.dataset;
             const decodedQueue = decodeURIComponent(queue);
-            if (window.confirmPurgeQueue && window.confirmPurgeQueue(decodedQueue)) {
-              window.purgeQueue?.(host, vhost, queue);
-            }
+            window.confirmPurgeQueue?.(decodedQueue, () => window.purgeQueue?.(host, vhost, queue));
           }
         });
     }

--- a/Src/static/main.js
+++ b/Src/static/main.js
@@ -90,6 +90,8 @@ class DashboardApp {
     window.confirmDeleteError = this.uiManager.confirmDeleteError.bind(this.uiManager);
     window.confirmTruncateDbErrors = this.uiManager.confirmTruncateDbErrors.bind(this.uiManager);
     window.confirmDeleteErrorsByPath = this.uiManager.confirmDeleteErrorsByPath.bind(this.uiManager);
+    window.confirmDeleteMessage = this.uiManager.confirmDeleteMessage.bind(this.uiManager);
+    window.confirmDeleteMessageGroup = this.uiManager.confirmDeleteMessageGroup.bind(this.uiManager);
 
     // ── Message detail modal ────────────────────────────────────────────────
     const _apiMgr  = this.apiManager;
@@ -240,11 +242,12 @@ class DashboardApp {
         const deleteBtn = e.target.closest('[data-action="delete-single-msg"]');
         if (deleteBtn) {
           const id = parseInt(deleteBtn.dataset.id, 10);
-          if (!confirm(`Delete message #${id}?`)) return;
-          await _apiMgr.deleteMessageById(id);
-          if (_msgDetailGroup) {
-            _loadMsgDetails(_msgDetailGroup.sampleId);
-          }
+          window.confirmDeleteMessage?.(id, async () => {
+            await _apiMgr.deleteMessageById(id);
+            if (_msgDetailGroup) {
+              _loadMsgDetails(_msgDetailGroup.sampleId);
+            }
+          });
         }
       });
 
@@ -265,15 +268,16 @@ class DashboardApp {
       _loadMsgDetails(sampleId);
     };
 
-    window.deleteMessageGroup = async () => {
+    window.deleteMessageGroup = () => {
       if (!_msgDetailGroup) return;
       const { sampleId, rawApp } = _msgDetailGroup;
-      if (!confirm(`Delete all "${rawApp}" messages in this group?`)) return;
-      const data = await _apiMgr.deleteMessageGroup(sampleId);
-      const modalEl = document.getElementById('messageDetailsModal');
-      bootstrap.Modal.getInstance(modalEl)?.hide();
-      _msgDetailGroup = null;
-      _dispMgr.showMessages(data);
+      window.confirmDeleteMessageGroup?.(rawApp, async () => {
+        const data = await _apiMgr.deleteMessageGroup(sampleId);
+        const modalEl = document.getElementById('messageDetailsModal');
+        bootstrap.Modal.getInstance(modalEl)?.hide();
+        _msgDetailGroup = null;
+        _dispMgr.showMessages(data);
+      });
     };
     // ── End message detail modal ────────────────────────────────────────────
 

--- a/Src/static/ui.js
+++ b/Src/static/ui.js
@@ -24,7 +24,11 @@ export class NotificationManager {
 
     if (typeof bootstrap === "undefined") {
       console.error("Bootstrap is not loaded");
-      window.alert(`${title}: ${message}`);
+      if (typeof $ !== "undefined" && typeof $.alert === "function") {
+        $.alert({ title, content: message, theme: "dark" });
+      } else {
+        window.alert(`${title}: ${message}`);
+      }
       return;
     }
 
@@ -52,12 +56,51 @@ export class NotificationManager {
   }
 }
 
+/**
+ * Shows a themed confirmation dialog via jQuery.confirm, invoking onConfirm
+ * only if the user confirms. Falls back to a native window.confirm if
+ * jQuery/jquery-confirm isn't loaded (content is stripped of markup first,
+ * since it's authored as HTML for the jQuery.confirm path).
+ */
+function showConfirm({ title, content, onConfirm }) {
+  if (typeof $ === "undefined" || typeof $.confirm !== "function") {
+    console.error("jQuery.confirm is not loaded");
+    if (window.confirm(`${title}\n\n${content.replace(/<[^>]+>/g, "")}`)) {
+      onConfirm?.();
+    }
+    return;
+  }
+
+  $.confirm({
+    title,
+    content,
+    theme: "dark",
+    type: "red",
+    buttons: {
+      confirm: {
+        text: "Yes",
+        btnClass: "btn-danger",
+        action: () => onConfirm?.(),
+      },
+      cancel: {
+        text: "Cancel",
+      },
+    },
+  });
+}
+
 export class UIManager {
   constructor(feedState, workflowLimiterState) {
     this.feedState = feedState;
     this.workflowLimiterState = workflowLimiterState;
     this.eventAssigned = false;
     this.eventAssignedError = false;
+  }
+
+  #esc(str) {
+    return String(str ?? '')
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 
   updateFeedPreference(toggle) {
@@ -113,30 +156,58 @@ export class UIManager {
     toggle.addEventListener("change", () => this.updateFeedPreference(toggle));
   }
 
-  confirmDelete(application) {
-    const message = `Are you sure you want to delete messages for ${decodeURIComponent(application)}?`;
-    return window.confirm(message);
+  confirmDelete(application, onConfirm) {
+    const message = `Are you sure you want to delete messages for ${this.#esc(decodeURIComponent(application))}?`;
+    showConfirm({ title: "Delete Messages", content: message, onConfirm });
   }
 
-  confirmTruncateMessages() {
-    return window.confirm("Are you sure you want to truncate all messages? This action cannot be undone.");
+  confirmTruncateMessages(onConfirm) {
+    showConfirm({
+      title: "Truncate All Messages",
+      content: "Are you sure you want to truncate all messages? This action cannot be undone.",
+      onConfirm,
+    });
   }
 
-  confirmPurgeQueue(queueName) {
-    return window.confirm(`Are you sure you want to purge all messages from queue "${queueName}"? This action cannot be undone.`);
+  confirmPurgeQueue(queueName, onConfirm) {
+    showConfirm({
+      title: "Purge Queue",
+      content: `Are you sure you want to purge all messages from queue "${this.#esc(queueName)}"? This action cannot be undone.`,
+      onConfirm,
+    });
   }
 
-  confirmDeleteError(directory) {
-    const message = `Are you sure you want to delete error_log file located at ${directory}?`;
-    return window.confirm(message);
+  confirmDeleteError(directory, onConfirm) {
+    const message = `Are you sure you want to delete error_log file located at ${this.#esc(directory)}?`;
+    showConfirm({ title: "Delete Error Log", content: message, onConfirm });
   }
 
-  confirmTruncateDbErrors() {
-    return window.confirm("Are you sure you want to truncate all DB error records? This action cannot be undone.");
+  confirmTruncateDbErrors(onConfirm) {
+    showConfirm({
+      title: "Truncate DB Errors",
+      content: "Are you sure you want to truncate all DB error records? This action cannot be undone.",
+      onConfirm,
+    });
   }
 
-  confirmDeleteErrorsByPath(path) {
-    return window.confirm(`Delete all DB error records for:\n${path}\n\nThis action cannot be undone.`);
+  confirmDeleteErrorsByPath(path, onConfirm) {
+    showConfirm({
+      title: "Delete DB Error Records",
+      content: `Delete all DB error records for:<br><code>${this.#esc(path)}</code><br><br>This action cannot be undone.`,
+      onConfirm,
+    });
+  }
+
+  confirmDeleteMessage(id, onConfirm) {
+    showConfirm({ title: "Delete Message", content: `Delete message #${this.#esc(id)}?`, onConfirm });
+  }
+
+  confirmDeleteMessageGroup(rawApp, onConfirm) {
+    showConfirm({
+      title: "Delete Message Group",
+      content: `Are you sure you want to delete all "${this.#esc(rawApp)}" messages in this group?`,
+      onConfirm,
+    });
   }
 }
 


### PR DESCRIPTION
## 📑 Description
Add jquery-confirm library to provide themed confirmation dialogs instead of browser alerts, improving the user experience. This change uses jquery-confirm for all confirmation prompts, offering a fallback to native confirm dialogues if jquery-confirm is unavailable, ensuring robustness. Updated various functions to enable callback functionality when confirmations are accepted, promoting a cleaner and more consistent interface. Also integrated jQuery for potential future enhancements.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Integrate jquery-confirm–based confirmation dialogs across the dashboard while preserving a native confirm fallback and updating call sites to use callback-driven confirmations.

New Features:
- Introduce a reusable showConfirm helper that shows themed jquery-confirm dialogs with a graceful fallback to window.confirm.
- Expose new UIManager confirmation methods for deleting single messages and message groups and wire them into the dashboard actions.

Enhancements:
- Replace direct window.confirm usage with centralized confirmation APIs that accept callbacks, simplifying control flow and enabling richer dialogs.
- Escape dynamic text used in confirmation messages to avoid unsafe HTML injection in dialog content.
- Update notification alerts to prefer jquery-confirm when Bootstrap toasts are unavailable for a more consistent UI.