### PR TITLE
chore: replace mhsendmail with Mailpit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # Base image
 FROM php:8.6-rc-apache
 
-# Set environment variables
-ENV GOPATH=/usr/local/go-packages \
-    PATH=/usr/local/go-packages/bin:/usr/local/go/bin:$PATH
-
 # Update apt and install dependencies in one layer
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -27,19 +23,21 @@ RUN apt-get update \
     # Clean up
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
-    # Install Go (using specific version and verifying checksum)
-    && mkdir -p "${GOPATH}/src" "${GOPATH}/bin" \
-    && curl -sSL "https://go.dev/dl/go1.20.5.linux-amd64.tar.gz" -o go.tar.gz \
-    && tar -C /usr/local -xzf go.tar.gz \
-    && rm go.tar.gz \
-    # Install mhsendmail (for email testing)
-    && go install github.com/mailhog/mhsendmail@latest \
-    && cp ${GOPATH}/bin/mhsendmail /usr/local/bin/mhsendmail \
+    # Install Mailpit (sendmail-compatible shim for email testing, replaces mhsendmail)
+    && ARCH="$(dpkg --print-architecture)" \
+    && curl -sSL "https://github.com/axllent/mailpit/releases/download/v1.30.5/mailpit-linux-${ARCH}.tar.gz" -o mailpit.tar.gz \
+    && tar -C /usr/local/bin -xzf mailpit.tar.gz mailpit \
+    && rm mailpit.tar.gz \
+    && chmod +x /usr/local/bin/mailpit \
+    # Keep the old mhsendmail path working as a compatibility shim (remove after config migration)
+    && printf '#!/bin/sh\nexec /usr/local/bin/mailpit sendmail "$@"\n' > /usr/local/bin/mhsendmail \
     && chmod +x /usr/local/bin/mhsendmail
 
 # Fail fast if required extensions are missing
 RUN php -m | grep -qi mbstring \
     && php -m | grep -qi mysqli \
+    && php -m | grep -qi sockets \
+    && php -m | grep -qi shmop \
     && php -m | grep -qi zip
 
 # Configure PHP base settings (can be overridden by mounted config)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,16 +38,16 @@ services:
       retries: 5
       start_period: 10s
 
-  smtp:
-    container_name: smtp
-    image: mailhog/mailhog:latest
+  mailpit:
+    container_name: mailpit
+    image: axllent/mailpit:latest
     ports:
       - "1025:1025"
       - "8025:8025"
     networks:
       - default
     healthcheck:
-      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:8025/"]
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:8025/readyz"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker/php/90-custom.ini
+++ b/docker/php/90-custom.ini
@@ -1,5 +1,5 @@
 [mail function]
-sendmail_path = "/usr/local/bin/mhsendmail --smtp-addr=mailhog:1025"
+sendmail_path = "/usr/local/bin/mailpit sendmail -S mailpit:1025"
 
 [PHP]
 upload_max_filesize = 10M


### PR DESCRIPTION
## 📑 Description
Replace mhsendmail with Mailpit for handling test emails. Update the Dockerfile to install Mailpit and create a mhsendmail compatibility script to ensure existing paths continue to function until configuration migration is complete. Update the PHP INI to use Mailpit for sendmail path. Change the docker-compose.yml to switch from MailHog to Mailpit, ensuring compatibility with existing service definitions. Adjust health check URL to account for Mailpit's readiness endpoint. These changes modernize the system and improve email testing reliability.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Replace the MailHog/mhsendmail-based test email setup with Mailpit, keeping a temporary shim for the old sendmail path.

New Features:
- Introduce Mailpit binary into the PHP Apache container for handling test emails.

Enhancements:
- Add a sendmail-compatible mhsendmail shim script to preserve existing paths during configuration migration.
- Update PHP configuration to use Mailpit for sendmail_path with the Mailpit SMTP service.
- Tighten Docker image PHP extension checks by asserting presence of sockets and shmop extensions.

Build:
- Simplify the Dockerfile by removing Go tooling and mhsendmail installation in favor of a direct Mailpit binary install.

Deployment:
- Switch docker-compose email service from MailHog to Mailpit and update its health check to use Mailpit's readiness endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the previous email testing service with Mailpit.
  * Added Mailpit’s web interface and SMTP service on the existing ports.
  * Updated application email delivery to use Mailpit.

* **Bug Fixes**
  * Improved container readiness checks for the email testing service.
  * Added validation for required PHP extensions, including sockets and shared memory support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->