### PR TITLE
feat: add DNS Records page and API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Projects Monitor is a PHP dashboard backed by a REST-like API (`Src/api/v1`). It
 - **GitHub integration** — open/pending pull requests, issues across repositories, workflow runs (failures highlighted), API rate-limit usage, and the latest releases of tracked projects.
 - **Webhooks & automation** — GitHub webhook statistics and processing-state counts, plus a right-hand **Actions** panel (offcanvas, top-right of the dashboard) listing live webhook workers and GStraccini Bot job runs.
 - **Infrastructure health** — HealthChecks.io, UpTimeRobot, AppVeyor CI, and Vercel deployment status; CloudAMQP/RabbitMQ queue, message, consumer, and connection stats; WireGuard VPN client/connection status over SSH.
-- **Domains** — DNS, registrar, and lifecycle information (expiration, transfer status) via IP2WHOIS.
+- **Domains** — registrar and lifecycle information (expiration, transfer status) via IP2WHOIS, plus a dedicated [DNS Records page](Src/dns.php) listing every zone record (A, CNAME, MX, TXT, ...) pulled live from cPanel, filterable by source domain/record type and sortable by any column.
 - **Logs & errors** — cPanel error logs and SQL-backed application errors, aggregated with grouping and statistics by application or error content.
 - **Public stats** — a pre-computed, unauthenticated stats page fed by a cron worker (see [Background workers](#background-workers)).
 - **Interactive API docs** — a Swagger UI served at `/api/v1/swagger`, backed by the OpenAPI spec at `/api/v1/openapi` (both behind login).
@@ -129,7 +129,7 @@ The dashboard is backed by a REST-like API under `/api/v1`, documented with a li
 - **Swagger UI:** `/api/v1/swagger`
 - **OpenAPI spec:** `/api/v1/openapi`
 
-Both require an authenticated session. Key endpoint groups: `github`, `webhooks*` (statistics, per-entity processing, worker control), `gstraccini-jobs` / `gstraccini-job-run`, `appveyor`, `cpanel`, `domains`, `healthchecksio`, `uptimerobot`, `vercel`, `queues` / `queues-purge`, `wireguard`, `messages*` / `errors*` (log retrieval, details, deletion), and `public-stats`.
+Both require an authenticated session. Key endpoint groups: `github`, `webhooks*` (statistics, per-entity processing, worker control), `gstraccini-jobs` / `gstraccini-job-run`, `appveyor`, `cpanel`, `dns-records`, `domains`, `healthchecksio`, `uptimerobot`, `vercel`, `queues` / `queues-purge`, `wireguard`, `messages*` / `errors*` (log retrieval, details, deletion), and `public-stats`.
 
 ---
 

--- a/Src/Library/CPanel.php
+++ b/Src/Library/CPanel.php
@@ -509,4 +509,156 @@ class CPanel
             return false;
         }
     }
+
+    /**
+     * Retrieves every domain that owns its own DNS zone on this cPanel account
+     * (main domain, addon domains, and parked domains). Subdomains are excluded
+     * since they live inside their parent domain's zone rather than owning one.
+     *
+     * @return array<int, string> Deduplicated list of zone domain names.
+     */
+    public function getZoneDomains(): array
+    {
+        $endpoint = 'execute/DomainInfo/list_domains';
+        $response = $this->getRequest($endpoint, '', []);
+
+        if ($response === null || empty($response->data)) {
+            return [];
+        }
+
+        $data = $response->data;
+        $domains = [];
+
+        if (!empty($data->main_domain)) {
+            $domains[] = $data->main_domain;
+        }
+
+        foreach (['addon_domains', 'parked_domains'] as $group) {
+            if (!empty($data->{$group}) && is_array($data->{$group})) {
+                foreach ($data->{$group} as $domain) {
+                    $domains[] = $domain;
+                }
+            }
+        }
+
+        return array_values(array_unique($domains));
+    }
+
+    /**
+     * Derives a human-readable destination value for a single DNS zone record,
+     * based on the record type. cPanel's ZoneEdit::fetchzone response stores the
+     * record's value under different fields depending on its type.
+     *
+     * @param object $record Raw record object from ZoneEdit::fetchzone.
+     * @param string $type Uppercased DNS record type (A, CNAME, MX, TXT, ...).
+     * @return string The record's destination/value.
+     */
+    private function resolveRecordDestination($record, string $type): string
+    {
+        switch ($type) {
+            case 'A':
+            case 'AAAA':
+                return $record->address ?? '';
+            case 'CNAME':
+                return rtrim($record->cname ?? '', '.');
+            case 'MX':
+                $preference = $record->preference ?? '';
+                $exchange = rtrim($record->exchange ?? '', '.');
+                return trim("{$preference} {$exchange}");
+            case 'TXT':
+                return $record->txtdata ?? '';
+            case 'NS':
+                return rtrim($record->nsdname ?? '', '.');
+            case 'PTR':
+                return rtrim($record->ptrdname ?? '', '.');
+            case 'SOA':
+                return rtrim($record->mname ?? '', '.');
+            case 'SRV':
+                $priority = $record->priority ?? '';
+                $weight = $record->weight ?? '';
+                $port = $record->port ?? '';
+                $target = rtrim($record->target ?? '', '.');
+                return trim("{$priority} {$weight} {$port} {$target}");
+            case 'CAA':
+                $flag = $record->flag ?? '';
+                $tag = $record->tag ?? '';
+                $value = $record->value ?? '';
+                return trim("{$flag} {$tag} {$value}");
+            default:
+                $skip = ['name', 'ttl', 'type', 'class', 'Line', 'line'];
+                $parts = [];
+                foreach ($record as $key => $value) {
+                    if (in_array($key, $skip, true) || $value === null || $value === '') {
+                        continue;
+                    }
+                    $parts[] = is_string($value) ? rtrim($value, '.') : $value;
+                }
+                return implode(' ', $parts);
+        }
+    }
+
+    /**
+     * Fetches and normalizes every DNS zone record for a single domain.
+     *
+     * @param string $domain The zone domain to fetch records for.
+     * @return array<int, array{domain: string, name: string, type: string, destination: string, ttl: string}>
+     */
+    private function parseZoneRecords(string $domain): array
+    {
+        $parameters = array(
+            "cpanel_jsonapi_module" => "ZoneEdit",
+            "cpanel_jsonapi_func"   => "fetchzone",
+            "cpanel_jsonapi_apiversion" => "2",
+            "domain" => $domain
+        );
+
+        $response = $this->getRequest("json-api", "cpanel", $parameters);
+        $records = $response->cpanelresult->data[0]->record ?? null;
+
+        if (empty($records)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($records as $record) {
+            if (empty($record->type)) {
+                continue;
+            }
+
+            $type = strtoupper($record->type);
+            $name = rtrim($record->name ?? $domain, '.');
+
+            $result[] = [
+                "domain" => $domain,
+                "name" => $name,
+                "type" => $type,
+                "destination" => $this->resolveRecordDestination($record, $type),
+                "ttl" => (string) ($record->ttl ?? '')
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Retrieves and normalizes every DNS zone record across every domain (and
+     * addon/parked domain) on this cPanel account. A domain whose zone fails to
+     * load is skipped rather than failing the whole request.
+     *
+     * @return array<int, array{domain: string, name: string, type: string, destination: string, ttl: string}>
+     */
+    public function getAllDnsRecords(): array
+    {
+        $result = [];
+
+        foreach ($this->getZoneDomains() as $domain) {
+            try {
+                $result = array_merge($result, $this->parseZoneRecords($domain));
+            } catch (RequestException) {
+                continue;
+            }
+        }
+
+        return $result;
+    }
 }

--- a/Src/api/v1/dns-records.php
+++ b/Src/api/v1/dns-records.php
@@ -1,0 +1,18 @@
+<?php
+
+require_once 'session_validator.php';
+require_once '../../vendor/autoload.php';
+
+use GuiBranco\ProjectsMonitor\Library\CPanel;
+use GuiBranco\ProjectsMonitor\Library\LogStream;
+
+LogStream::info("API request received", ["endpoint" => "GET /api/v1/dns-records"], "api");
+$cPanel = new CPanel();
+$data = array();
+try {
+    $data["records"] = $cPanel->getAllDnsRecords();
+} catch (Exception $e) {
+    $data["records"] = [];
+    $data["error"] = "Failed to retrieve DNS records: " . $e->getMessage();
+}
+echo json_encode($data);

--- a/Src/api/v1/openapi.json
+++ b/Src/api/v1/openapi.json
@@ -24,6 +24,7 @@
   "tags": [
     { "name": "AppVeyor",    "description": "AppVeyor CI build data" },
     { "name": "cPanel",      "description": "cPanel server stats and error-log file management" },
+    { "name": "DNS",         "description": "cPanel DNS zone records for all hosted domains" },
     { "name": "Domains",     "description": "Domain SSL/expiry validity information" },
     { "name": "Errors",      "description": "Database-backed error log management" },
     { "name": "GitHub",      "description": "GitHub API stats, issues, pull requests, and releases" },
@@ -259,6 +260,45 @@
             }
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/v1/dns-records": {
+      "get": {
+        "summary": "DNS zone records",
+        "description": "Returns every DNS zone record (A, AAAA, CNAME, MX, TXT, NS, and more) across every domain hosted on the cPanel account, each tagged with its source (zone) domain.",
+        "operationId": "getDnsRecords",
+        "tags": ["DNS"],
+        "responses": {
+          "200": {
+            "description": "DNS zone record data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "records": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "domain": { "type": "string", "description": "Source (zone) domain." },
+                          "name": { "type": "string", "description": "Full record name." },
+                          "type": { "type": "string", "description": "Record type (A, CNAME, MX, TXT, ...)." },
+                          "destination": { "type": "string", "description": "Record value/destination." },
+                          "ttl": { "type": "string" }
+                        }
+                      }
+                    },
+                    "error": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "429": { "$ref": "#/components/responses/RateLimited" },
           "500": { "$ref": "#/components/responses/ServerError" }

--- a/Src/dns.php
+++ b/Src/dns.php
@@ -1,0 +1,133 @@
+<?php
+require_once 'session.php';
+require_once 'vendor/autoload.php';
+
+use GuiBranco\ProjectsMonitor\Library\Configuration;
+
+if (!isset($_SESSION['last_activity']) || time() - $_SESSION['last_activity'] > 1800) {
+    session_unset();
+    session_destroy();
+    header('Location: login.php');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    exit;
+}
+$_SESSION['last_activity'] = time();
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    exit;
+}
+$username = $_SESSION['username'] ?? '';
+$configuration = new Configuration();
+?>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+   <title>Projects Monitor | DNS Records</title>
+   <meta charset="utf-8">
+   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+      integrity="sha512-dPXYcDub/aeb08c63jRq/k6GaKccl256JQy/AnOq7CAnEZ9FzSL9wSbcZkMp4R26vBsMLFYH4kQ67/bbV8XaCQ=="
+      crossorigin="anonymous">
+   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gridjs@6.2.0/dist/theme/mermaid.min.css"
+      integrity="sha384-i8iPOOXHyYKlqvjJjbORq7m/VrfUhgupTg3IZvtXz8M7c0CiTPUUhM5gdjiQiGbv"
+      crossorigin="anonymous">
+   <link rel="preconnect" href="https://fonts.googleapis.com">
+   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
+   <link rel="stylesheet" href="static/styles.css?<?php echo filemtime("static/styles.css"); ?>">
+</head>
+
+<body>
+   <div id="toast-container"></div>
+
+   <nav class="navbar navbar-dark fixed-top" id="main-navbar">
+      <div class="container-fluid px-4">
+         <span class="navbar-brand d-flex align-items-center gap-2">
+            <i class="bi bi-hdd-network fs-5"></i>
+            <span class="fw-bold">DNS Records</span>
+         </span>
+         <div class="d-flex align-items-center gap-3">
+            <a href="index.php" class="btn btn-sm btn-nav-action">
+               <i class="bi bi-arrow-left"></i>
+               <span class="ms-1">Back to Dashboard</span>
+            </a>
+            <span class="navbar-user d-none d-lg-flex align-items-center gap-2">
+               <i class="bi bi-person-circle"></i>
+               <span><?php echo htmlspecialchars($username); ?></span>
+            </span>
+            <a href="logout.php" class="btn btn-sm btn-danger">
+               <i class="bi bi-box-arrow-right"></i>
+               <span class="d-none d-md-inline ms-1">Logout</span>
+            </a>
+         </div>
+      </div>
+   </nav>
+
+   <div class="dashboard-layout">
+      <div class="dashboard-container">
+
+         <div class="full-width-section">
+            <div class="section-header">
+               <i class="bi bi-funnel me-2"></i>Filters
+            </div>
+            <div class="section-content">
+               <div class="dns-filters">
+                  <div class="dns-filter-group">
+                     <div class="dns-filter-group-header">
+                        <span><i class="bi bi-globe me-1"></i>Source Domain</span>
+                        <span>
+                           <button type="button" class="btn btn-sm btn-outline-light" id="dns_domains_all">All</button>
+                           <button type="button" class="btn btn-sm btn-outline-light" id="dns_domains_none">None</button>
+                        </span>
+                     </div>
+                     <div class="dns-filter-list" id="dns_filter_domains">
+                        <div class="text-muted small px-2">Loading…</div>
+                     </div>
+                  </div>
+                  <div class="dns-filter-group">
+                     <div class="dns-filter-group-header">
+                        <span><i class="bi bi-tag me-1"></i>Record Type</span>
+                        <span>
+                           <button type="button" class="btn btn-sm btn-outline-light" id="dns_types_all">All</button>
+                           <button type="button" class="btn btn-sm btn-outline-light" id="dns_types_none">None</button>
+                        </span>
+                     </div>
+                     <div class="dns-filter-list" id="dns_filter_types">
+                        <div class="text-muted small px-2">Loading…</div>
+                     </div>
+                  </div>
+               </div>
+            </div>
+         </div>
+
+         <div class="full-width-section">
+            <div class="section-header">
+               <i class="bi bi-hdd-network me-2"></i>DNS Zone Records <span id="counter_dns_records"
+                  class="badge rounded-pill"></span>
+            </div>
+            <div class="section-content">
+               <div id="dns_records_table"></div>
+            </div>
+         </div>
+
+      </div>
+   </div>
+
+   <?php include_once __DIR__ . '/footer.php'; ?>
+
+   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha256-CDOy6cOibCWEdsRiZuaHf8dSGGJRYuBGC+mjoJimHGw=" crossorigin="anonymous"></script>
+   <script src="https://cdn.jsdelivr.net/npm/gridjs@6.2.0/dist/gridjs.umd.js"
+      integrity="sha384-y62I+ZvjNRolkugL/AMpUZykqrL6oqYxBruObmlDAhDpmapM0s+xgvVK+wGVpza0"
+      crossorigin="anonymous"></script>
+   <script type="module" src="static/dns.js?<?php echo filemtime("static/dns.js"); ?>"></script>
+</body>
+
+</html>

--- a/Src/index.php
+++ b/Src/index.php
@@ -414,6 +414,10 @@ $configuration = new Configuration();
             <div class="data-item">
                <div class="section-header">
                   <i class="bi bi-globe me-2"></i>Domains <span id="counter_domains" class="badge rounded-pill"></span>
+                  <a href="dns.php" class="btn btn-sm btn-nav-action ms-2" title="View DNS Records"
+                     onclick="event.stopPropagation()">
+                     <i class="bi bi-hdd-network"></i>
+                  </a>
                </div>
                <div id="domains" class="section-content"></div>
             </div>

--- a/Src/static/constants.js
+++ b/Src/static/constants.js
@@ -29,6 +29,7 @@ export const API_ENDPOINTS = {
   QUEUES: "api/v1/queues",
   QUEUES_PURGE: "api/v1/queues/purge",
   DOMAINS: "api/v1/domains",
+  DNS_RECORDS: "api/v1/dns-records",
   ERRORS: "api/v1/errors",
   ERRORS_TRUNCATE: "api/v1/errors/truncate",
   ERRORS_DELETE_PATH: "api/v1/errors/delete-path",

--- a/Src/static/dns.js
+++ b/Src/static/dns.js
@@ -1,0 +1,164 @@
+// dns.js — dedicated DNS Records page (filterable, sortable Grid.js table)
+import { API_ENDPOINTS } from './constants.js';
+import { ApiManager } from './api.js';
+import { NotificationManager } from './ui.js';
+
+const TYPE_BADGE_CLASS = {
+  A: 'dns-badge-a',
+  AAAA: 'dns-badge-a',
+  CNAME: 'dns-badge-cname',
+  MX: 'dns-badge-mx',
+  TXT: 'dns-badge-txt',
+  NS: 'dns-badge-ns',
+  SOA: 'dns-badge-soa',
+  PTR: 'dns-badge-ptr',
+  SRV: 'dns-badge-srv',
+  CAA: 'dns-badge-caa',
+};
+
+class DnsRecordsPage {
+  constructor() {
+    this.apiManager = new ApiManager();
+    this.gridjs = window.gridjs;
+    this.records = [];
+    this.activeDomains = new Set();
+    this.activeTypes = new Set();
+    this.grid = null;
+  }
+
+  start() {
+    this.apiManager.load(API_ENDPOINTS.DNS_RECORDS, (data) => this.onData(data));
+  }
+
+  onData(data) {
+    if (data && data.error) {
+      NotificationManager.show('Error', data.error, 'error');
+    }
+
+    this.records = Array.isArray(data && data.records) ? data.records : [];
+
+    // Preserve the user's current filter selection across reloads; only
+    // default to "everything selected" the very first time data arrives.
+    const isFirstLoad = this.activeDomains.size === 0 && this.activeTypes.size === 0;
+    if (isFirstLoad) {
+      this.distinctValues('domain').forEach((v) => this.activeDomains.add(v));
+      this.distinctValues('type').forEach((v) => this.activeTypes.add(v));
+    }
+
+    this.renderFilters();
+    this.renderTable();
+  }
+
+  distinctValues(field) {
+    return [...new Set(this.records.map((r) => r[field]).filter((v) => v !== undefined && v !== null && v !== ''))].sort();
+  }
+
+  filteredRecords() {
+    return this.records.filter(
+      (r) => this.activeDomains.has(r.domain) && this.activeTypes.has(r.type)
+    );
+  }
+
+  renderFilters() {
+    this.renderFilterGroup('dns_filter_domains', 'domain', this.activeDomains);
+    this.renderFilterGroup('dns_filter_types', 'type', this.activeTypes);
+
+    document.getElementById('dns_domains_all')?.addEventListener('click', () => this.setAll('domain', this.activeDomains, true));
+    document.getElementById('dns_domains_none')?.addEventListener('click', () => this.setAll('domain', this.activeDomains, false));
+    document.getElementById('dns_types_all')?.addEventListener('click', () => this.setAll('type', this.activeTypes, true));
+    document.getElementById('dns_types_none')?.addEventListener('click', () => this.setAll('type', this.activeTypes, false));
+  }
+
+  renderFilterGroup(containerId, field, activeSet) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    const values = this.distinctValues(field);
+
+    if (values.length === 0) {
+      container.innerHTML = '<div class="text-muted small px-2">No records found.</div>';
+      return;
+    }
+
+    container.innerHTML = values
+      .map((value, i) => {
+        const id = `${containerId}_${i}`;
+        const checked = activeSet.has(value) ? 'checked' : '';
+        return `
+          <div class="form-check dns-filter-item">
+            <input class="form-check-input" type="checkbox" id="${id}" value="${value}" ${checked}>
+            <label class="form-check-label" for="${id}">${value}</label>
+          </div>`;
+      })
+      .join('');
+
+    container.querySelectorAll('input[type="checkbox"]').forEach((input) => {
+      input.addEventListener('change', () => {
+        if (input.checked) {
+          activeSet.add(input.value);
+        } else {
+          activeSet.delete(input.value);
+        }
+        this.renderTable();
+      });
+    });
+  }
+
+  setAll(field, activeSet, selected) {
+    activeSet.clear();
+    if (selected) {
+      this.distinctValues(field).forEach((v) => activeSet.add(v));
+    }
+    this.renderFilters();
+    this.renderTable();
+  }
+
+  typeBadge(type) {
+    const cls = TYPE_BADGE_CLASS[type] || 'dns-badge-default';
+    return this.gridjs.html(`<span class="dns-type-badge ${cls}">${type}</span>`);
+  }
+
+  renderTable() {
+    const el = document.getElementById('dns_records_table');
+    if (!el) return;
+
+    const filtered = this.filteredRecords();
+    const counter = document.getElementById('counter_dns_records');
+    if (counter) {
+      counter.textContent = `${filtered.length} / ${this.records.length}`;
+    }
+
+    const data = filtered.map((r) => [r.domain, r.name, r.type, r.destination, r.ttl]);
+
+    const columns = [
+      { name: 'Source Domain', sort: true },
+      { name: 'Name', sort: true },
+      {
+        name: 'Type',
+        sort: true,
+        formatter: (cell) => this.typeBadge(cell),
+      },
+      { name: 'Destination', sort: true },
+      { name: 'TTL', sort: true },
+    ];
+
+    if (this.grid) {
+      this.grid.updateConfig({ columns, data }).forceRender();
+      return;
+    }
+
+    this.grid = new this.gridjs.Grid({
+      columns,
+      data,
+      sort: true,
+      pagination: { limit: 25, summary: true },
+      search: true,
+      resizable: false,
+      className: { table: 'gridjs-table-dark' },
+    });
+    this.grid.render(el);
+  }
+}
+
+const page = new DnsRecordsPage();
+window.addEventListener('load', () => page.start());

--- a/Src/static/styles.css
+++ b/Src/static/styles.css
@@ -1195,3 +1195,79 @@ footer a {
 footer a:hover {
   color: rgba(255, 255, 255, 0.8) !important;
 }
+
+/* ===========================================
+   DNS RECORDS PAGE
+   =========================================== */
+.dns-filters {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+@media (max-width: 768px) {
+  .dns-filters {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dns-filter-group {
+  background: var(--glass-bg-light);
+  border: 1px solid var(--glass-border-light);
+  border-radius: var(--border-radius-small);
+  padding: 12px;
+}
+
+.dns-filter-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  padding: 4px 6px 10px;
+}
+
+.dns-filter-list {
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 4px 6px;
+}
+
+.dns-filter-item {
+  padding: 3px 0;
+}
+
+.dns-filter-item .form-check-input {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.dns-filter-item .form-check-input:checked {
+  background-color: #ff6b35;
+  border-color: #ff6b35;
+}
+
+.dns-filter-item .form-check-label {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.dns-type-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: #fff;
+}
+
+.dns-badge-a { background: #2563eb; }
+.dns-badge-cname { background: #7c3aed; }
+.dns-badge-mx { background: #ff6b35; }
+.dns-badge-txt { background: #16a34a; }
+.dns-badge-ns { background: #64748b; }
+.dns-badge-soa { background: #475569; }
+.dns-badge-ptr { background: #0891b2; }
+.dns-badge-srv { background: #ca8a04; }
+.dns-badge-caa { background: #db2777; }
+.dns-badge-default { background: #334155; }


### PR DESCRIPTION
## 📑 Description
Introduce a dedicated DNS Records page (`dns.php`) to list DNS zone records for domains managed by the cPanel account. Implement filters for source domain and record type, allowing users to sort and search the records easily. Enhance the CPanel class to support DNS record retrieval with new methods: `getZoneDomains()`, `getAllDnsRecords()`, and utility functions for parsing individual zone records.

Update endpoint definitions with a new `dns-records` API, exposed at `/api/v1/dns-records`, enabling front-end components to fetch and display DNS data. Modify documentation and README to reflect this addition.

This enhancement aids users in managing DNS configurations more efficiently and quickly accessing relevant record information.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a dedicated DNS Records page and backing API that surface normalized DNS zone records from cPanel for all managed domains.

New Features:
- Introduce a DNS Records dashboard page (dns.php) with filterable, searchable, and sortable DNS zone records using Grid.js.
- Expose a new REST endpoint at /api/v1/dns-records that returns normalized DNS records aggregated from all cPanel DNS zones.
- Add DNS navigation from the Domains section in the main dashboard to the new DNS Records page.

Enhancements:
- Extend the CPanel library to list zone-owning domains and to fetch and normalize DNS zone records across all domains.
- Style DNS-specific filters and record-type badges to integrate with the existing dashboard look and feel.

Documentation:
- Update README to document the DNS Records page and the new dns-records API endpoint among the core features and endpoint groups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated DNS Records page accessible from the Domains section.
  * View DNS records across hosted domains with domain and record-type filters.
  * Search, sort, paginate, and monitor record counts in the DNS records table.
  * Added support for common DNS record types, including type badges and responsive styling.
  * Added an authenticated DNS records API endpoint with documented responses.

* **Documentation**
  * Documented the DNS Records page and API endpoint in the README and API specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->