### PR TITLE
refactor: optimize SSH monitoring and server health display +semver: minor

### DIFF
--- a/Src/Library/SSH.php
+++ b/Src/Library/SSH.php
@@ -26,6 +26,9 @@ class SSH
     /** @var array<int, array{name: string, host: string, port?: int, username: string, privateKey: string}>|null Cached hosts from ssh.secrets.php. */
     private static $hostsCache = null;
 
+    /** @var array|null Memoized monitor-report payload, so a single instance never runs the remote script twice. */
+    private $reportCache = null;
+
     /**
      * Connects to the given host, or to the default host (the entry named
      * "Vinhedo1" in ssh.secrets.php, falling back to the first entry) when omitted.
@@ -117,10 +120,16 @@ class SSH
      * /usr/local/bin/monitor-report) and returns its decoded JSON payload.
      * This single script run is the source of both the system health report
      * and the WireGuard peer list — vinhedo1's sudoers no longer permits
-     * running `wg show` directly, only this wrapped script.
+     * running `wg show` directly, only this wrapped script. The result is
+     * memoized per instance since callers (getSystemReport(), getResourceUsage())
+     * may both need it for the same host within one request.
      */
     private function fetchMonitorReport(): array
     {
+        if ($this->reportCache !== null) {
+            return $this->reportCache;
+        }
+
         if (!$this->connected) {
             throw new SshException('Not connected');
         }
@@ -137,7 +146,7 @@ class SSH
             throw new \Exception('Unable to parse monitor-report output');
         }
 
-        return $report;
+        return $this->reportCache = $report;
     }
 
     /**

--- a/Src/api/v1/system-report.php
+++ b/Src/api/v1/system-report.php
@@ -7,7 +7,18 @@ use GuiBranco\ProjectsMonitor\Library\SSH;
 use GuiBranco\ProjectsMonitor\Library\LogStream;
 
 LogStream::info("API request received", ["endpoint" => "GET /api/v1/system-report"], "api");
-$ssh = new SSH();
+
+$reports = array();
+
+foreach (SSH::getHosts() as $hostConfig) {
+    $ssh = new SSH($hostConfig);
+    $reports[] = array(
+        "name"    => $ssh->getName(),
+        "rows"    => $ssh->getSystemReport(),
+        "metrics" => $ssh->getResourceUsage()["metrics"],
+    );
+}
+
 $data = array();
-$data["system_report"] = $ssh->getSystemReport();
+$data["system_reports"] = $reports;
 echo json_encode($data);

--- a/Src/index.php
+++ b/Src/index.php
@@ -163,9 +163,6 @@ $configuration = new Configuration();
             <i class="bi bi-speedometer2 me-2"></i>Gauges
          </div>
          <div id="gauges_section" class="gauges-grid section-content">
-            <div id="gauge_chart_cpu" class="gauge"></div>
-            <div id="gauge_chart_memory" class="gauge"></div>
-            <div id="gauge_chart_process" class="gauge"></div>
             <div id="gauge_chart_emails" class="gauge"></div>
             <div id="gauge_chart_log_errors" class="gauge"></div>
             <div id="gauge_chart_github_usage" class="gauge"></div>
@@ -536,10 +533,20 @@ $configuration = new Configuration();
 
       <div class="full-width-section">
          <div class="section-header">
-            <i class="bi bi-hdd-rack me-2"></i>Server Health (vinhedo1) <span id="counter_system_report"
+            <i class="bi bi-hdd-rack me-2"></i>Server Health <span id="counter_server_health"
                class="badge rounded-pill"></span>
          </div>
-         <div id="system_report" class="section-content"></div>
+         <div id="server_health" class="section-content">
+            <div class="server-health-card">
+               <div class="server-health-name">Osasco (cPanel)</div>
+               <div class="server-health-gauges">
+                  <div id="gauge_chart_cpu" class="gauge"></div>
+                  <div id="gauge_chart_memory" class="gauge"></div>
+                  <div id="gauge_chart_process" class="gauge"></div>
+               </div>
+            </div>
+            <div id="server_health_ssh_hosts"></div>
+         </div>
       </div>
 
       <div class="full-width-section">

--- a/Src/static/dataDisplay.js
+++ b/Src/static/dataDisplay.js
@@ -915,11 +915,63 @@ export class DataDisplayManager {
   }
 
   /**
-   * Draws the remote server health report (load, memory, disk, services)
-   * collected via SSH from vinhedo1.
+   * Renders per-host server health for every configured OCI host
+   * (Vinhedo1-4): a CPU/Memory/Disk gauge row plus the detailed metrics
+   * table (load, memory, disk, services), one card per host. Osasco's
+   * gauges live in a separate static card populated by showCPanel().
    */
   showSystemReport(response) {
-    this.chartManager.drawDataTable(response.system_report, "system_report", CHART_OPTIONS.table);
+    const container = document.getElementById("server_health_ssh_hosts");
+    const counterEl = document.getElementById("counter_server_health");
+    if (!container) return;
+
+    const reports = Array.isArray(response.system_reports) ? response.system_reports : [];
+    if (counterEl) counterEl.textContent = 1 + reports.length;
+
+    if (reports.length === 0) {
+      container.innerHTML = '<p class="text-muted text-center py-3 mb-0">No additional servers configured</p>';
+      return;
+    }
+
+    container.innerHTML = reports
+      .map((report, i) => `
+        <div class="server-health-card">
+          <div class="server-health-name">${this.#escHtml(report.name)}</div>
+          <div class="server-health-gauges">
+            <div id="gauge_chart_ssh_${i}_cpu" class="gauge"></div>
+            <div id="gauge_chart_ssh_${i}_memory" class="gauge"></div>
+            <div id="gauge_chart_ssh_${i}_disk" class="gauge"></div>
+          </div>
+          <div id="system_report_${i}" class="section-content"></div>
+        </div>`)
+      .join('');
+
+    const gaugeOptions = {
+      width: "100%",
+      height: "100%",
+      min: 0,
+      max: 100,
+      greenFrom: 0,
+      greenTo: 75,
+      yellowFrom: 75,
+      yellowTo: 90,
+      redFrom: 90,
+      redTo: 100,
+    };
+
+    reports.forEach((report, i) => {
+      const metrics = report.metrics ?? {};
+      this.chartManager.drawGaugeChart("CPU", metrics.cpu?.percent ?? 0, `gauge_chart_ssh_${i}_cpu`, gaugeOptions);
+      this.chartManager.drawGaugeChart("Memory", metrics.memory?.percent ?? 0, `gauge_chart_ssh_${i}_memory`, gaugeOptions);
+      this.chartManager.drawGaugeChart("Disk", metrics.disk?.percent ?? 0, `gauge_chart_ssh_${i}_disk`, gaugeOptions);
+
+      const tableEl = document.getElementById(`system_report_${i}`);
+      if (report.rows && report.rows.length > 0) {
+        this.chartManager.drawDataTable(report.rows, `system_report_${i}`, CHART_OPTIONS.table);
+      } else if (tableEl) {
+        tableEl.innerHTML = '<p class="text-muted text-center py-2 mb-0 small">Unable to reach this host</p>';
+      }
+    });
   }
 
   /**

--- a/Src/static/styles.css
+++ b/Src/static/styles.css
@@ -752,6 +752,33 @@ input.gridjs-input {
 }
 
 /* ===========================================
+   SERVER HEALTH
+   =========================================== */
+.server-health-card {
+  @extend .glass-card-light;
+  padding: 15px;
+  margin-bottom: 15px;
+}
+
+.server-health-card:last-child {
+  margin-bottom: 0;
+}
+
+.server-health-name {
+  font-weight: 600;
+  font-size: 1.05rem;
+  margin-bottom: 10px;
+  color: var(--text-primary);
+}
+
+.server-health-gauges {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  margin-bottom: 10px;
+}
+
+/* ===========================================
    GRID LAYOUTS
    =========================================== */
 .gauges-grid {


### PR DESCRIPTION
## 📑 Description
Enhance the SSH class by introducing memoization for monitor reports, preventing multiple script executions on a single instance. This reduces overhead and improves efficiency. Additionally, update system-report API to iterate through all configured SSH hosts, compiling individual system reports.

Adjust the frontend to dynamically render each host's server health data, providing organized visual feedback using server health cards. This aligns with the backend changes, where reports are now collated for multiple servers, and the UI reflects this aggregated data.

Remove redundant gauges and improve CSS for server health dashboard, ensuring a clean and responsive layout. These changes help present server metrics clearly and concisely to the end-user.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Aggregate SSH-based server health reports for all configured hosts and update the UI to present per-host health cards alongside the existing cPanel gauges.

New Features:
- Expose system health and resource usage for multiple SSH hosts via the system-report API.
- Render server health cards per SSH host, each with CPU, memory, and disk gauges plus a detailed metrics table.

Enhancements:
- Memoize SSH monitor-report responses per instance to avoid running the remote script multiple times in a single request.
- Refine the server health dashboard layout and styling for clearer, more organized presentation of per-host metrics.